### PR TITLE
Bump upper bound on network-transport-tests.

### DIFF
--- a/network-transport-tcp.cabal
+++ b/network-transport-tcp.cabal
@@ -45,7 +45,7 @@ Test-Suite TestTCP
   Type:            exitcode-stdio-1.0
   Main-Is:         TestTCP.hs
   Build-Depends:   base >= 4.3 && < 5,
-                   network-transport-tests >= 0.1.0.1 && < 0.2,
+                   network-transport-tests >= 0.1.0.1 && < 0.3,
                    network >= 2.3 && < 2.5,
                    network-transport >= 0.4.0.0 && < 0.5,
                    network-transport-tcp >= 0.3 && < 0.5


### PR DESCRIPTION
This fixes CI, in turn making it possible to compile and test the other currently outstanding PR's, in particular @snoyberg's.

@hyperthunk note that `network-transport-tests-0.2` is currently not on Hackage. Omission?
