### PR TITLE
Change tcpNoDelay default to be the same as TCP_NODELAY.

### DIFF
--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -538,7 +538,7 @@ defaultTCPParameters = TCPParameters {
     tcpBacklog         = N.sOMAXCONN
   , tcpReuseServerAddr = True
   , tcpReuseClientAddr = True
-  , tcpNoDelay         = True
+  , tcpNoDelay         = False
   }
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
@mboes points out that it is less surprising to the user if we use the same defaults as the TCP layer, which I think makes sense.