### PR TITLE
Rename extensions to default-extensions

### DIFF
--- a/network-transport-tcp.cabal
+++ b/network-transport-tcp.cabal
@@ -53,7 +53,7 @@ Test-Suite TestTCP
                    network-transport-tcp >= 0.3 && < 0.5
   ghc-options:     -threaded -rtsopts -with-rtsopts=-N
   HS-Source-Dirs:  tests
-  Extensions:      CPP,
+  default-extensions:      CPP,
                    OverloadedStrings
   default-language: Haskell2010
   If flag(use-mock-network)
@@ -83,7 +83,7 @@ Test-Suite TestQC
     Buildable: False
   ghc-options:    -threaded -Wall -fno-warn-orphans
   HS-Source-Dirs: tests
-  Extensions:     TypeSynonymInstances
+  default-extensions: TypeSynonymInstances
                   FlexibleInstances
                   OverlappingInstances
                   OverloadedStrings


### PR DESCRIPTION
Removes usage of deprecated fields