### PR TITLE
recvExact will read 0 bytes

### DIFF
--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -693,8 +693,15 @@ apiSend (ourEndPoint, theirEndPoint) connId connAlive payload =
         RemoteEndPointValid vst -> do
           alive <- readIORef connAlive
           if alive
-            then sched theirEndPoint $
-              sendOn vst (encodeInt32 connId : prependLength payload)
+            then sched theirEndPoint $ case payload of
+              -- If there's no bytes, don't put anything on the wire.
+              [] -> pure ()
+              -- If there are bytes, send them with a connection id and length
+              -- prefix. This includes 0-length input such as
+              --   [""]
+              --   ["", ""]
+              --   etc.
+              _ -> sendOn vst (encodeInt32 connId : prependLength payload)
             else throwIO $ TransportError SendClosed "Connection closed"
         RemoteEndPointClosing _ _ -> do
           alive <- readIORef connAlive

--- a/src/Network/Transport/TCP/Internal.hs
+++ b/src/Network/Transport/TCP/Internal.hs
@@ -128,6 +128,12 @@ recvExact :: N.Socket                -- ^ Socket to read from
           -> Int32                   -- ^ Number of bytes to read
           -> IO [ByteString]
 recvExact _ len | len < 0 = throwIO (userError "recvExact: Negative length")
+recvExact sock len | len == 0 = do
+  -- Special handling for reading 0 bytes. In the positive case we loop until
+  -- the number of outstanding bytes is 0, and don't read on the 0 case, but
+  -- here we must read exactly 0 bytes.
+  bs <- NBS.recv sock 0
+  pure [bs]
 recvExact sock len = go [] len
   where
     go :: [ByteString] -> Int32 -> IO [ByteString]


### PR DESCRIPTION
If a client sends "", a server will pick it up as [""] rather than [].