### PR TITLE
Queueing and buffering for an EndPoint

### DIFF
--- a/network-transport-tcp.cabal
+++ b/network-transport-tcp.cabal
@@ -30,7 +30,9 @@ Library
                    data-accessor >= 0.2 && < 0.3,
                    containers >= 0.4 && < 0.6,
                    bytestring >= 0.9 && < 0.11,
-                   network >= 2.6.2 && < 2.7
+                   network >= 2.6.2 && < 2.7,
+                   pqueue == 1.3.2,
+                   stm
   Exposed-modules: Network.Transport.TCP,
                    Network.Transport.TCP.Internal
   Default-Extensions: CPP

--- a/network-transport-tcp.cabal
+++ b/network-transport-tcp.cabal
@@ -30,9 +30,7 @@ Library
                    data-accessor >= 0.2 && < 0.3,
                    containers >= 0.4 && < 0.6,
                    bytestring >= 0.9 && < 0.11,
-                   network >= 2.6.2 && < 2.7,
-                   pqueue == 1.3.2,
-                   stm
+                   network >= 2.6.2 && < 2.7
   Exposed-modules: Network.Transport.TCP,
                    Network.Transport.TCP.Internal
   Default-Extensions: CPP

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -568,9 +568,6 @@ createTransportExposeInternals host port params = do
                 -> ThreadId
                 -> IO (Transport, TransportInternals)
     mkTransport transport tid = do
-      let newEndPointInternal :: (forall t . QDisc t)
-                              -> IO (Either (TransportError NewEndPointErrorCode) EndPoint)
-          newEndPointInternal qdisc = apiNewEndPoint transport qdisc
       return
         ( Transport
             { newEndPoint = do
@@ -666,10 +663,6 @@ apiNewEndPoint transport qdisc =
 --   thread in your program rather than some chatty network peer. The 'Event'
 --   which is to be enqueued is given to 'qdiscEnqueue' so that the 'QDisc'
 --   can know about open connections, their identifiers and peer addresses, etc.
---
---   See 'newEndPointInternal', which expects a 'forall t . QDisc t', a queue
---   discipline which does not use any details of the particular thing it's
---   queueing.
 data QDisc t = QDisc {
     qdiscDequeue :: IO t
   , qdiscEnqueue :: Event -> t -> IO ()

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -573,10 +573,8 @@ createTransportExposeInternals host port params = do
             { newEndPoint = do
                 qdisc <- simpleUnboundedQDisc
                 apiNewEndPoint transport qdisc
-            , closeTransport = let evs = [ EndPointClosed
-                                         , throw $ userError "Transport closed"
-                                         ] in
-                               apiCloseTransport transport (Just tid) evs
+            , closeTransport = let evs = [ EndPointClosed ]
+                               in apiCloseTransport transport (Just tid) evs
             }
         , TransportInternals
             { transportThread = tid
@@ -632,10 +630,8 @@ apiNewEndPoint transport qdisc =
       { receive       = takeEvent (localQueue ourEndPoint)
       , address       = localAddress ourEndPoint
       , connect       = apiConnect (transportParams transport) ourEndPoint
-      , closeEndPoint = let evs = [ EndPointClosed
-                                  , throw $ userError "Endpoint closed"
-                                  ] in
-                        apiCloseEndPoint transport evs ourEndPoint
+      , closeEndPoint = let evs = [ EndPointClosed ]
+                        in  apiCloseEndPoint transport evs ourEndPoint
       , newMulticastGroup     = return . Left $ newMulticastGroupError
       , resolveMulticastGroup = return . Left . const resolveMulticastGroupError
       }

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -498,10 +498,8 @@ data TCPParameters = TCPParameters {
     -- This can be overriden for each connect call with
     -- 'ConnectHints'.'connectTimeout'.
   , transportConnectTimeout :: Maybe Int
-    -- | Create a QDisc for an EndPoint. This is uniform over the whole
-    -- transport: every EndPoint will have the same QDisc, although possibly
-    -- with independent state (that's why it's in IO).
-  , tcpQDisc :: forall t . IO (QDisc t)
+    -- | Create a QDisc for an EndPoint.
+  , tcpNewQDisc :: forall t . IO (QDisc t)
   }
 
 -- | Internal functionality we expose for unit testing
@@ -571,7 +569,7 @@ createTransportExposeInternals host port params = do
       return
         ( Transport
             { newEndPoint = do
-                qdisc <- tcpQDisc params
+                qdisc <- tcpNewQDisc params
                 apiNewEndPoint transport qdisc
             , closeTransport = let evs = [ EndPointClosed ]
                                in apiCloseTransport transport (Just tid) evs
@@ -598,7 +596,7 @@ defaultTCPParameters = TCPParameters {
   , tcpNoDelay         = False
   , tcpKeepAlive       = False
   , tcpUserTimeout     = Nothing
-  , tcpQDisc           = simpleUnboundedQDisc
+  , tcpNewQDisc        = simpleUnboundedQDisc
   , transportConnectTimeout = Nothing
   }
 

--- a/tests/TestTCP.hs
+++ b/tests/TestTCP.hs
@@ -635,13 +635,15 @@ testReconnect = do
           Left _ -> return ()
           Right _ -> throwIO $ userError "testConnect: unexpected send success"
 
+    ErrorEvent (TransportError (EventConnectionLost _) _) <- receive endpoint
+
     -- The third attempt succeeds
     Right conn1 <- connect endpoint theirAddr ReliableOrdered defaultConnectHints
 
     -- But a send will fail because the server has closed the connection again
     threadDelay 100000
     Left (TransportError SendFailed _) <- send conn1 ["ping"]
-    ErrorEvent (TransportError (EventConnectionLost _) _) <- receive endpoint
+
 
     -- But a subsequent call to connect should reestablish the connection
     Right conn2 <- connect endpoint theirAddr ReliableOrdered defaultConnectHints


### PR DESCRIPTION
Abstracted the use of `Chan`/`readChan`/`writeChan` so that we can give more complicated queueing and buffering policies.