### PR TITLE
apiCloseEndPoint blocks until no longer reciving

### DIFF
--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -565,6 +565,7 @@ createTransportExposeInternals bindHost bindPort mkExternal params = do
                              bindPort
                              (tcpBacklog params)
                              (tcpReuseServerAddr params)
+                             (errorHandler transport)
                              (terminationHandler transport)
                              (handleConnectionRequest transport))
                       (\(_port', tid) -> killThread tid)
@@ -588,6 +589,9 @@ createTransportExposeInternals bindHost bindPort mkExternal params = do
             , socketBetween   = internalSocketBetween transport
             }
         )
+
+    errorHandler :: TCPTransport -> SomeException -> IO ()
+    errorHandler _ = throwIO
 
     terminationHandler :: TCPTransport -> SomeException -> IO ()
     terminationHandler transport ex = do

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -854,6 +854,7 @@ apiCloseEndPoint transport evs ourEndPoint =
                 [ encodeWord32 (encodeControlHeader CloseEndPoint) ]
               -- Release probing resources if probing.
               forM_ (remoteProbing vst) id
+              tryShutdownSocketBoth (remoteSocket vst)
               remoteSocketClosed vst
             return closed
           RemoteEndPointClosing resolved vst -> do
@@ -865,7 +866,9 @@ apiCloseEndPoint transport evs ourEndPoint =
             -- Since we replace the state in this MVar with 'closed', it's
             -- guaranteed that no other actions will be scheduled after this
             -- one.
-            sched theirEndPoint $ remoteSocketClosed vst
+            sched theirEndPoint $ do
+              tryShutdownSocketBoth (remoteSocket vst)
+              remoteSocketClosed vst
             return closed
           RemoteEndPointClosed ->
             return st

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -1194,10 +1194,10 @@ handleIncomingMessages params (ourEndPoint, theirEndPoint) = do
                 -- Release probing resources if probing.
                 forM_ (remoteProbing vst) id
                 removeRemoteEndPoint (ourEndPoint, theirEndPoint)
-                putMVar resolved ()
                 -- Nothing to do, but we want to indicate that the socket
                 -- really did close.
                 act <- schedule theirEndPoint $ return ()
+                putMVar resolved ()
                 return (RemoteEndPointClosed, Just act)
           RemoteEndPointFailed err ->
             throwIO err

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -566,7 +566,7 @@ createTransportExposeInternals bindHost bindPort mkExternal params = do
                              (tcpBacklog params)
                              (tcpReuseServerAddr params)
                              (terminationHandler transport)
-                             (Right (handleConnectionRequest transport)))
+                             (handleConnectionRequest transport))
                       (\(_port', tid) -> killThread tid)
                       (\(port'', tid) -> (port'',) <$> mkTransport transport tid)
        return result

--- a/tests/TestTCP.hs
+++ b/tests/TestTCP.hs
@@ -17,7 +17,11 @@ import Network.Transport.TCP ( createTransport
                              , createTransportExposeInternals
                              , TransportInternals(..)
                              , encodeEndPointAddress
+<<<<<<< 0ea96b4d1f2d1c02e14c632cae0d36f8196d8e1b
                              , TCPParameters(..)
+=======
+                             , decodeEndPointAddress
+>>>>>>> Try to shutdown sockets when closing endpoints
                              , defaultTCPParameters
                              , LightweightConnectionId
                              )
@@ -65,6 +69,15 @@ import qualified Network.Socket as N
   , AddrInfo
   , shutdown
   , ShutdownCmd(ShutdownSend)
+  , SockAddr(..)
+  , SocketType(Stream)
+  , AddrInfo(..)
+  , getAddrInfo
+  , defaultHints
+  , defaultProtocol
+  , socket
+  , connect
+  , close
   )
 
 #ifdef USE_MOCK_NETWORK
@@ -902,6 +915,48 @@ testMaxLength = do
   closeTransport goodClientTransport
   closeTransport serverTransport
 
+-- | Ensure that an end point closes up OK even if the peer disobeys the
+--   protocol.
+testCloseEndPoint :: IO ()
+testCloseEndPoint = do
+
+  serverAddress <- newEmptyMVar
+  serverFinished <- newEmptyMVar
+
+  -- A server which accepts one connection and then attempts to close the
+  -- end point.
+  forkTry $ do
+    Right transport <- createTransport "127.0.0.1" "0" defaultTCPParameters
+    Right ep <- newEndPoint transport
+    putMVar serverAddress (address ep)
+    ConnectionOpened _ _ _ <- receive ep
+    Just () <- timeout 5000000 (closeEndPoint ep)
+    putMVar serverFinished ()
+    return ()
+
+  -- A nefarious client which connects to the server then stops responding.
+  forkTry $ do
+    Just (hostName, serviceName, endPointId) <- decodeEndPointAddress <$> readMVar serverAddress
+    addr:_ <- N.getAddrInfo (Just N.defaultHints) (Just hostName) (Just serviceName)
+    sock <- N.socket (N.addrFamily addr) N.Stream N.defaultProtocol
+    N.connect sock (N.addrAddress addr)
+    sendMany sock [
+        encodeWord32 endPointId
+      -- Our addres... we'll just make it up.
+      -- TODO there are plans to verify peer addresses, and also plans to
+      -- support peers which do not know their external address (due to NAT
+      -- perhaps). Update this test to use that feature once it's here.
+      , encodeWord32 5
+      , "hello"
+      -- Create a lightweight connection.
+      , encodeWord32 (encodeControlHeader CreatedNewConnection)
+      , encodeWord32 1024
+      ]
+    readMVar serverFinished
+    N.close sock
+
+  readMVar serverFinished
+
 main :: IO ()
 main = do
   tcpResult <- tryIO $ runTests
@@ -919,6 +974,7 @@ main = do
            , ("UnidirectionalError",    testUnidirectionalError)
            , ("InvalidCloseConnection", testInvalidCloseConnection)
            , ("MaxLength",              testMaxLength)
+           , ("CloseEndPoint",          testCloseEndPoint)
            ]
   -- Run the generic tests even if the TCP specific tests failed..
   testTransport (either (Left . show) (Right) <$>

--- a/tests/TestTCP.hs
+++ b/tests/TestTCP.hs
@@ -16,12 +16,9 @@ import Network.Transport
 import Network.Transport.TCP ( createTransport
                              , createTransportExposeInternals
                              , TransportInternals(..)
-                             , encodeEndPointAddress
-<<<<<<< 0ea96b4d1f2d1c02e14c632cae0d36f8196d8e1b
                              , TCPParameters(..)
-=======
+                             , encodeEndPointAddress
                              , decodeEndPointAddress
->>>>>>> Try to shutdown sockets when closing endpoints
                              , defaultTCPParameters
                              , LightweightConnectionId
                              )
@@ -951,7 +948,7 @@ testCloseEndPoint = do
   -- A server which accepts one connection and then attempts to close the
   -- end point.
   forkTry $ do
-    Right transport <- createTransport "127.0.0.1" "0" defaultTCPParameters
+    Right transport <- createTransport "127.0.0.1" "0" ((,) "127.0.0.1") defaultTCPParameters
     Right ep <- newEndPoint transport
     putMVar serverAddress (address ep)
     ConnectionOpened _ _ _ <- receive ep

--- a/tests/TestTCP.hs
+++ b/tests/TestTCP.hs
@@ -176,7 +176,7 @@ testEarlyDisconnect = do
       tlog "Client"
 
       -- Listen for incoming messages
-      (clientPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO $ \socketFree sock -> do
+      (clientPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree sock -> do
         -- Initial setup
         0 <- recvWord32 sock
         _ <- recvWithLength maxBound sock
@@ -288,7 +288,7 @@ testEarlyCloseSocket = do
       tlog "Client"
 
       -- Listen for incoming messages
-      (clientPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO $ \socketFree sock -> do
+      (clientPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree sock -> do
         -- Initial setup
         0 <- recvWord32 sock
         _ <- recvWithLength maxBound sock
@@ -639,7 +639,7 @@ testReconnect = do
   counter <- newMVar (0 :: Int)
 
   -- Server
-  (serverPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO $ \socketFree sock -> do
+  (serverPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree sock -> do
     -- Accept the connection
     Right 0  <- tryIO $ recvWord32 sock
     Right _  <- tryIO $ recvWithLength maxBound sock
@@ -741,7 +741,7 @@ testUnidirectionalError = do
   serverGotPing <- newEmptyMVar
 
   -- Server
-  (serverPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO $ \socketFree sock -> do
+  (serverPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree sock -> do
     -- We accept connections, but when an exception occurs we don't do
     -- anything (in particular, we don't close the socket). This is important
     -- because when we shutdown one direction of the socket a recv here will

--- a/tests/TestTCP.hs
+++ b/tests/TestTCP.hs
@@ -964,12 +964,8 @@ testCloseEndPoint = do
     N.connect sock (N.addrAddress addr)
     sendMany sock [
         encodeWord32 endPointId
-      -- Our addres... we'll just make it up.
-      -- TODO there are plans to verify peer addresses, and also plans to
-      -- support peers which do not know their external address (due to NAT
-      -- perhaps). Update this test to use that feature once it's here.
-      , encodeWord32 5
-      , "hello"
+      , encodeWord32 13
+      , "127.0.0.1:0:0"
       -- Create a lightweight connection.
       , encodeWord32 (encodeControlHeader CreatedNewConnection)
       , encodeWord32 1024


### PR DESCRIPTION
When testing components built atop network-transport-tcp, it's sometimes
desirable to have a test case create an end point at the beginning of
the test and close it at the end, where all test cases share the same
transport. If we run such a test repeatedly, as is the typical style
when quick-checking, for instance, then we risk undefined behaviour: when
the next test case runs, the end point from the previous test case,
although closed, may still be receiving on one of its sockets. The
sockets have all been closed, their file-descriptors freed up, and so we
get undefined behaviour. This can be catastrophic: the stray thread can
steal `recv`s from the next end point's sockets, completely breaking the
protocol and for instance causing the end point to receive an incorrect
length prefix.

## An example that I observed

When the next end point opens a heavyweight connection, the stray
thread may read the end point identifier (int32), causing the new end
point to read the length prefix of the end point address as the end
point id, and the first 4 bytes of the end point address as the length
of the end point address itself. That will either cause it to get the
wrong end point address, or as I observed, to hang indefinitely because
those first 4 bytes are a very large number.

## Solution

I *think* this patch solves the issue, but this is about concurrency so I'm
always cautious. Please take a look. I have a test case like what I
described above: client and server create new end points at each
iteration, exchange a `send`, then close up. Without this patch, it'll typically
freeze (but not always!). With this patch, it seems to never do so, but the
tests run quite a bit more slowly, and that makes sense: `closeEndPoint`
now has to wait for its sockets handler threads to finish. 

To start, take a look at `forkServer`. It's been changed so that you can give
a choice of handlers: a `Right` if you want `forkServer` to take care of
closing the socket when your handler is done, and a `Left` for the old
behaviour. Both are there because the test cases rely on the old behaviour.

The `forkServer` used by `createTransport` will use `Right`. This means that
`forkServer` will fork a new thread for each connection, and run
`handleConnectionRequest`, which no longer forks `handleIncomingMessages`.
Instead, it finishes when `handleIncomingMessages` finishes. That's the
action which repeatedly `recv`s on the socket, so it's good to know that the
socket will be closed only when that action has finished (and no more `recv`s
will happen).

The handler is also given an `IO ()` which will return immediately after the
socket is indeed closed. This is put into the `ValidRemoteEndPointState`
and `apiCloseEndPoint` makes use of it to ensure that it returns only when
every remote end point's socket has been closed.

The other point at which a socket is created, `socketToEndPoint`, implements
the same scheme: if a socket is created then there's also an `IO ()` which
returns when that socket has been closed (when `handleIncomingMessages`
has finished).