### PR TITLE
Explicitly use Word32, avoid use of Enum

### DIFF
--- a/network-transport-tcp.cabal
+++ b/network-transport-tcp.cabal
@@ -26,7 +26,7 @@ Flag use-mock-network
 
 Library
   Build-Depends:   base >= 4.3 && < 5,
-                   network-transport >= 0.4.1.0 && < 0.5,
+                   network-transport >= 0.5 && < 0.6,
                    data-accessor >= 0.2 && < 0.3,
                    containers >= 0.4 && < 0.6,
                    bytestring >= 0.9 && < 0.11,
@@ -49,7 +49,7 @@ Test-Suite TestTCP
   Build-Depends:   base >= 4.3 && < 5,
                    network-transport-tests >= 0.2.1.0 && < 0.3,
                    network >= 2.3 && < 2.7,
-                   network-transport >= 0.4.1.0 && < 0.5,
+                   network-transport >= 0.5 && < 0.6,
                    network-transport-tcp
   ghc-options:     -threaded -rtsopts -with-rtsopts=-N
   HS-Source-Dirs:  tests

--- a/network-transport-tcp.cabal
+++ b/network-transport-tcp.cabal
@@ -49,7 +49,7 @@ Test-Suite TestTCP
   Build-Depends:   base >= 4.3 && < 5,
                    network-transport-tests >= 0.2.1.0 && < 0.3,
                    network >= 2.3 && < 2.7,
-                   network-transport >= 0.5 && < 0.6,
+                   network-transport,
                    network-transport-tcp
   ghc-options:     -threaded -rtsopts -with-rtsopts=-N
   HS-Source-Dirs:  tests

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -56,7 +56,6 @@ import Network.Transport.TCP.Internal
   , decodeConnectionRequestResponse
   , forkServer
   , recvWithLength
-  , recvInt32
   , recvWord32
   , encodeWord32
   , tryCloseSocket
@@ -980,7 +979,7 @@ handleIncomingMessages (ourEndPoint, theirEndPoint) = do
     -- exception thrown by 'recv'.
     go :: N.Socket -> IO ()
     go sock = do
-      lcid <- recvWord32 sock :: IO Word32
+      lcid <- recvWord32 sock :: IO LightweightConnectionId
       if lcid >= firstNonReservedLightweightConnectionId
         then do
           readMessage sock lcid
@@ -1762,7 +1761,7 @@ socketToEndPoint (EndPointAddress ourAddress) theirAddress reuseAddr noDelay kee
         mapIOException failed $ do
           sendMany sock
                    (encodeWord32 theirEndPointId : prependLength [ourAddress])
-          recvInt32 sock
+          recvWord32 sock
       case decodeConnectionRequestResponse response of
         Nothing -> throwIO (failed . userError $ "Unexpected response")
         Just r  -> return (sock, r)

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -48,14 +48,21 @@ import Prelude hiding
 
 import Network.Transport
 import Network.Transport.TCP.Internal
-  ( forkServer
+  ( ControlHeader(..)
+  , encodeControlHeader
+  , decodeControlHeader
+  , ConnectionRequestResponse(..)
+  , encodeConnectionRequestResponse
+  , decodeConnectionRequestResponse
+  , forkServer
   , recvWithLength
   , recvInt32
+  , recvWord32
+  , encodeWord32
   , tryCloseSocket
   )
 import Network.Transport.Internal
-  ( encodeInt32
-  , prependLength
+  ( prependLength
   , mapIOException
   , tryIO
   , tryToEnum
@@ -448,32 +455,6 @@ type LightweightConnectionId = Word32
 -- 'LightweightConnectionId'.
 type HeavyweightConnectionId = Word32
 
--- | Control headers
-data ControlHeader =
-    -- | Tell the remote endpoint that we created a new connection
-    CreatedNewConnection
-    -- | Tell the remote endpoint we will no longer be using a connection
-  | CloseConnection
-    -- | Request to close the connection (see module description)
-  | CloseSocket
-    -- | Sent by an endpoint when it is closed.
-  | CloseEndPoint
-    -- | Message sent to probe a socket
-  | ProbeSocket
-    -- | Acknowledgement of the ProbeSocket message
-  | ProbeSocketAck
-  deriving (Enum, Bounded, Show)
-
--- | Response sent by /B/ to /A/ when /A/ tries to connect
-data ConnectionRequestResponse =
-    -- | /B/ accepts the connection
-    ConnectionRequestAccepted
-    -- | /A/ requested an invalid endpoint
-  | ConnectionRequestInvalid
-    -- | /A/s request crossed with a request from /B/ (see protocols)
-  | ConnectionRequestCrossed
-  deriving (Enum, Bounded, Show)
-
 -- | Parameters for setting up the TCP transport
 data TCPParameters = TCPParameters {
     -- | Backlog for 'listen'.
@@ -743,7 +724,10 @@ apiClose (ourEndPoint, theirEndPoint) connId connAlive =
             then do
               writeIORef connAlive False
               sched theirEndPoint $
-                sendOn vst [encodeInt32 CloseConnection, encodeInt32 connId]
+                sendOn vst [
+                    encodeWord32 (encodeControlHeader CloseConnection)
+                  , encodeWord32 connId
+                  ]
               return ( RemoteEndPointValid
                      . (remoteOutgoing ^: (\x -> x - 1))
                      $ vst
@@ -773,7 +757,7 @@ apiSend (ourEndPoint, theirEndPoint) connId connAlive payload =
           alive <- readIORef connAlive
           if alive
             then sched theirEndPoint $
-              sendOn vst (encodeInt32 connId : prependLength payload)
+              sendOn vst (encodeWord32 connId : prependLength payload)
             else throwIO $ TransportError SendClosed "Connection closed"
         RemoteEndPointClosing _ _ -> do
           alive <- readIORef connAlive
@@ -829,7 +813,8 @@ apiCloseEndPoint transport evs ourEndPoint =
             return closed
           RemoteEndPointValid vst -> do
             sched theirEndPoint $ do
-              void $ tryIO $ sendOn vst [ encodeInt32 CloseEndPoint ]
+              void $ tryIO $ sendOn vst
+                [ encodeWord32 (encodeControlHeader CloseEndPoint) ]
               -- Release probing resources if probing.
               forM_ (remoteProbing vst) id
               tryCloseSocket (remoteSocket vst)
@@ -869,7 +854,7 @@ handleConnectionRequest transport sock = handle handleException $ do
       N.setSocketOption sock N.KeepAlive 1
     forM_ (tcpUserTimeout $ transportParams transport) $
       N.setSocketOption sock N.UserTimeout
-    ourEndPointId <- recvInt32 sock
+    ourEndPointId <- recvWord32 sock
     theirAddress  <- EndPointAddress . BS.concat <$> recvWithLength sock
     let ourAddress = encodeEndPointAddress (transportHost transport)
                                            (transportPort transport)
@@ -878,7 +863,7 @@ handleConnectionRequest transport sock = handle handleException $ do
       TransportValid vst ->
         case vst ^. localEndPointAt ourAddress of
           Nothing -> do
-            sendMany sock [encodeInt32 ConnectionRequestInvalid]
+            sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestInvalid)]
             throwIO $ userError "handleConnectionRequest: Invalid endpoint"
           Just ourEndPoint ->
             return ourEndPoint
@@ -896,7 +881,8 @@ handleConnectionRequest transport sock = handle handleException $ do
 
         if not isNew
           then do
-            void $ tryIO $ sendMany sock [encodeInt32 ConnectionRequestCrossed]
+            void $ tryIO $ sendMany sock
+              [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestCrossed)]
             probeIfValid theirEndPoint
             tryCloseSocket sock
             return Nothing
@@ -911,7 +897,7 @@ handleConnectionRequest transport sock = handle handleException $ do
                         , _remoteMaxIncoming   = 0
                         , _remoteNextConnOutId = firstNonReservedLightweightConnectionId
                         }
-            sendMany sock [encodeInt32 ConnectionRequestAccepted]
+            sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestAccepted)]
             resolveInit (ourEndPoint, theirEndPoint) (RemoteEndPointValid vst)
             return (Just theirEndPoint)
       -- If we left the scope of the exception handler with a return value of
@@ -939,7 +925,8 @@ handleConnectionRequest transport sock = handle handleException $ do
               let params = transportParams transport
               void $ tryIO $ System.Timeout.timeout
                   (maybe (-1) id $ transportConnectTimeout params) $ do
-                sendMany (remoteSocket vst) [encodeInt32 ProbeSocket]
+                sendMany (remoteSocket vst)
+                  [encodeWord32 (encodeControlHeader ProbeSocket)]
                 threadDelay maxBound
               -- Discard the connection if this thread is not killed (i.e. the
               -- probe ack does not arrive on time).
@@ -993,21 +980,21 @@ handleIncomingMessages (ourEndPoint, theirEndPoint) = do
     -- exception thrown by 'recv'.
     go :: N.Socket -> IO ()
     go sock = do
-      lcid <- recvInt32 sock :: IO LightweightConnectionId
+      lcid <- recvWord32 sock :: IO Word32
       if lcid >= firstNonReservedLightweightConnectionId
         then do
           readMessage sock lcid
           go sock
         else
-          case tryToEnum (fromIntegral lcid) of
+          case decodeControlHeader lcid of
             Just CreatedNewConnection -> do
-              recvInt32 sock >>= createdNewConnection
+              recvWord32 sock >>= createdNewConnection
               go sock
             Just CloseConnection -> do
-              recvInt32 sock >>= closeConnection
+              recvWord32 sock >>= closeConnection
               go sock
             Just CloseSocket -> do
-              didClose <- recvInt32 sock >>= closeSocket sock
+              didClose <- recvWord32 sock >>= closeSocket sock
               unless didClose $ go sock
             Just CloseEndPoint -> do
               let closeRemoteEndPoint vst = do
@@ -1033,7 +1020,7 @@ handleIncomingMessages (ourEndPoint, theirEndPoint) = do
                 _                           -> return s
               tryCloseSocket sock
             Just ProbeSocket -> do
-              forkIO $ sendMany sock [encodeInt32 ProbeSocketAck]
+              forkIO $ sendMany sock [encodeWord32 (encodeControlHeader ProbeSocketAck)]
               go sock
             Just ProbeSocketAck -> do
               stopProbing
@@ -1139,9 +1126,10 @@ handleIncomingMessages (ourEndPoint, theirEndPoint) = do
                 removeRemoteEndPoint (ourEndPoint, theirEndPoint)
                 -- Attempt to reply (but don't insist)
                 act <- schedule theirEndPoint $ do
-                  void $ tryIO $ sendOn vst' [ encodeInt32 CloseSocket
-                                             , encodeInt32 (vst ^. remoteMaxIncoming)
-                                             ]
+                  void $ tryIO $ sendOn vst'
+                    [ encodeWord32 (encodeControlHeader CloseSocket)
+                    , encodeWord32 (vst ^. remoteMaxIncoming)
+                    ]
                   tryCloseSocket sock
                 return (RemoteEndPointClosed, Just act)
           RemoteEndPointClosing resolved vst ->  do
@@ -1293,7 +1281,10 @@ createConnectionTo params ourEndPoint theirAddress hints = do
               RemoteEndPointValid vst -> do
                 let connId = vst ^. remoteNextConnOutId
                 act <- schedule theirEndPoint $ do
-                  sendOn vst [encodeInt32 CreatedNewConnection, encodeInt32 connId]
+                  sendOn vst [
+                      encodeWord32 (encodeControlHeader CreatedNewConnection)
+                    , encodeWord32 connId
+                    ]
                   return connId
                 return ( RemoteEndPointValid
                        $ remoteNextConnOutId ^= connId + 1
@@ -1381,8 +1372,8 @@ closeIfUnused (ourEndPoint, theirEndPoint) = do
         then do
           resolved <- newEmptyMVar
           act <- schedule theirEndPoint $
-            sendOn vst [ encodeInt32 CloseSocket
-                       , encodeInt32 (vst ^. remoteMaxIncoming)
+            sendOn vst [ encodeWord32 (encodeControlHeader CloseSocket)
+                       , encodeWord32 (vst ^. remoteMaxIncoming)
                        ]
           return (RemoteEndPointClosing resolved vst, Just act)
         else
@@ -1770,9 +1761,9 @@ socketToEndPoint (EndPointAddress ourAddress) theirAddress reuseAddr noDelay kee
           N.connect sock (N.addrAddress addr)
         mapIOException failed $ do
           sendMany sock
-                   (encodeInt32 theirEndPointId : prependLength [ourAddress])
+                   (encodeWord32 theirEndPointId : prependLength [ourAddress])
           recvInt32 sock
-      case tryToEnum response of
+      case decodeConnectionRequestResponse response of
         Nothing -> throwIO (failed . userError $ "Unexpected response")
         Just r  -> return (sock, r)
   where

--- a/src/Network/Transport/TCP/Internal.hs
+++ b/src/Network/Transport/TCP/Internal.hs
@@ -1,9 +1,17 @@
 -- | Utility functions for TCP sockets
 module Network.Transport.TCP.Internal
-  ( forkServer
+  ( ControlHeader(..)
+  , encodeControlHeader
+  , decodeControlHeader
+  , ConnectionRequestResponse(..)
+  , encodeConnectionRequestResponse
+  , decodeConnectionRequestResponse
+  , forkServer
   , recvWithLength
   , recvExact
   , recvInt32
+  , recvWord32
+  , encodeWord32
   , tryCloseSocket
   ) where
 
@@ -11,7 +19,13 @@ module Network.Transport.TCP.Internal
 import Prelude hiding (catch)
 #endif
 
-import Network.Transport.Internal (decodeInt32, void, tryIO, forkIOWithUnmask)
+import Network.Transport.Internal
+  ( decodeInt32
+  , encodeInt32
+  , void
+  , tryIO
+  , forkIOWithUnmask
+  )
 
 #ifdef USE_MOCK_NETWORK
 import qualified Network.Transport.TCP.Mock.Socket as N
@@ -44,6 +58,8 @@ import qualified Network.Socket.ByteString as NBS (recv)
 #endif
 
 import Control.Concurrent (ThreadId)
+import Data.Word (Word32)
+
 import Control.Monad (forever, when)
 import Control.Exception (SomeException, catch, bracketOnError, throwIO, mask_)
 import Control.Applicative ((<$>), (<*>))
@@ -51,6 +67,65 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS (length, concat, null)
 import Data.Int (Int32)
 import Data.ByteString.Lazy.Internal (smallChunkSize)
+
+-- | Control headers
+data ControlHeader =
+    -- | Tell the remote endpoint that we created a new connection
+    CreatedNewConnection
+    -- | Tell the remote endpoint we will no longer be using a connection
+  | CloseConnection
+    -- | Request to close the connection (see module description)
+  | CloseSocket
+    -- | Sent by an endpoint when it is closed.
+  | CloseEndPoint
+    -- | Message sent to probe a socket
+  | ProbeSocket
+    -- | Acknowledgement of the ProbeSocket message
+  | ProbeSocketAck
+  deriving (Show)
+
+decodeControlHeader :: Word32 -> Maybe ControlHeader
+decodeControlHeader w32 = case w32 of
+  0 -> Just CreatedNewConnection
+  1 -> Just CloseConnection
+  2 -> Just CloseSocket
+  3 -> Just CloseEndPoint
+  4 -> Just ProbeSocket
+  5 -> Just ProbeSocketAck
+  _ -> Nothing
+
+encodeControlHeader :: ControlHeader -> Word32
+encodeControlHeader ch = case ch of
+  CreatedNewConnection -> 0
+  CloseConnection -> 1
+  CloseSocket -> 2
+  CloseEndPoint -> 3
+  ProbeSocket -> 4
+  ProbeSocketAck -> 5
+
+-- | Response sent by /B/ to /A/ when /A/ tries to connect
+data ConnectionRequestResponse =
+    -- | /B/ accepts the connection
+    ConnectionRequestAccepted
+    -- | /A/ requested an invalid endpoint
+  | ConnectionRequestInvalid
+    -- | /A/s request crossed with a request from /B/ (see protocols)
+  | ConnectionRequestCrossed
+  deriving (Show)
+
+decodeConnectionRequestResponse :: Word32 -> Maybe ConnectionRequestResponse
+decodeConnectionRequestResponse w32 = case w32 of
+  0 -> Just ConnectionRequestAccepted
+  1 -> Just ConnectionRequestInvalid
+  2 -> Just ConnectionRequestCrossed
+  _ -> Nothing
+
+encodeConnectionRequestResponse :: ConnectionRequestResponse -> Word32
+encodeConnectionRequestResponse crr = case crr of
+  ConnectionRequestAccepted -> 0
+  ConnectionRequestInvalid -> 1
+  ConnectionRequestCrossed -> 2
+
 
 -- | Start a server at the specified address.
 --
@@ -109,13 +184,22 @@ forkServer host port backlog reuseAddr terminationHandler requestHandler = do
 
 -- | Read a length and then a payload of that length
 recvWithLength :: N.Socket -> IO [ByteString]
-recvWithLength sock = recvInt32 sock >>= recvExact sock
+recvWithLength sock = recvWord32 sock >>= recvExact sock
 
 -- | Receive a 32-bit integer
 recvInt32 :: Num a => N.Socket -> IO a
 recvInt32 sock = decodeInt32 . BS.concat <$> recvExact sock 4
 
--- | Close a socket, ignoring I/O exceptions
+-- | Receive a 32-bit unsigned integer
+recvWord32 :: N.Socket -> IO Word32
+recvWord32 = recvInt32
+
+-- | Encode a Word32. Alias for network-transport's encodeInt32, which in fact
+--   encodes an arbitrary Enum.
+encodeWord32 :: Word32 -> ByteString
+encodeWord32 = encodeInt32
+
+-- | Close a socket, ignoring I/O exceptions.
 tryCloseSocket :: N.Socket -> IO ()
 tryCloseSocket sock = void . tryIO $
   N.sClose sock
@@ -125,12 +209,12 @@ tryCloseSocket sock = void . tryIO $
 -- Throws an I/O exception if the socket closes before the specified
 -- number of bytes could be read
 recvExact :: N.Socket                -- ^ Socket to read from
-          -> Int32                   -- ^ Number of bytes to read
+          -> Word32                  -- ^ Number of bytes to read
           -> IO [ByteString]
 recvExact _ len | len < 0 = throwIO (userError "recvExact: Negative length")
 recvExact sock len = go [] len
   where
-    go :: [ByteString] -> Int32 -> IO [ByteString]
+    go :: [ByteString] -> Word32 -> IO [ByteString]
     go acc 0 = return (reverse acc)
     go acc l = do
       bs <- NBS.recv sock (fromIntegral l `min` smallChunkSize)

--- a/src/Network/Transport/TCP/Internal.hs
+++ b/src/Network/Transport/TCP/Internal.hs
@@ -95,11 +95,11 @@ decodeControlHeader w32 = case w32 of
 encodeControlHeader :: ControlHeader -> Word32
 encodeControlHeader ch = case ch of
   CreatedNewConnection -> 0
-  CloseConnection -> 1
-  CloseSocket -> 2
-  CloseEndPoint -> 3
-  ProbeSocket -> 4
-  ProbeSocketAck -> 5
+  CloseConnection      -> 1
+  CloseSocket          -> 2
+  CloseEndPoint        -> 3
+  ProbeSocket          -> 4
+  ProbeSocketAck       -> 5
 
 -- | Response sent by /B/ to /A/ when /A/ tries to connect
 data ConnectionRequestResponse =
@@ -121,9 +121,8 @@ decodeConnectionRequestResponse w32 = case w32 of
 encodeConnectionRequestResponse :: ConnectionRequestResponse -> Word32
 encodeConnectionRequestResponse crr = case crr of
   ConnectionRequestAccepted -> 0
-  ConnectionRequestInvalid -> 1
-  ConnectionRequestCrossed -> 2
-
+  ConnectionRequestInvalid  -> 1
+  ConnectionRequestCrossed  -> 2
 
 -- | Start a server at the specified address.
 --


### PR DESCRIPTION
This patch eliminates the use of signed integers and
makes the text more explicit about what is being decoded from the wire.
`recvInt32` is not so clear about this: it would in fact receive a `Word32`
almost always, except in the case of control headers and connection
request responses, which would read a signed `Int` and pass it to
`tryToEnum` (`recvInt32` actually receives any `Num` type).

Similar story for encoding: `encodeInt32` would acutally encode any
`Enum` by using `fromEnum` and encoding the signed `Int`, but now
we encode a `Word32` explicitly.

Haddock says that `Int` is only guaranteed to have range
`[-2^29, 2^29 - 1]`. But `LightweightConnectionId = Word32` so we could
have a problem in `handleIncomingMessages`: the peer could give a valid
connection id which is interpreted as a control header.
With this patch it's fine: the `Word32` won't be cast to an `Int`.

`ControlHeader` and `ConnectionRequestResponse` have been moved to
the internal module, and are encoded/decoded explicitly rather than through
their `Enum` and `Bounded` instances, so that we don't have to use any
signed integers ever.