### PR TITLE
Optional limits on address and data length

### DIFF
--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -55,7 +55,7 @@ import Network.Transport.TCP.Internal
   , encodeConnectionRequestResponse
   , decodeConnectionRequestResponse
   , forkServer
-  , recvWithLength
+  , recvWithLengthLimited
   , recvWord32
   , encodeWord32
   , tryCloseSocket
@@ -482,6 +482,10 @@ data TCPParameters = TCPParameters {
   , transportConnectTimeout :: Maybe Int
     -- | Create a QDisc for an EndPoint.
   , tcpNewQDisc :: forall t . IO (QDisc t)
+    -- | Optional maximum length (in bytes) for a peer's address.
+  , tcpMaxAddressLength :: Maybe Word32
+    -- | Optional maximum length (in bytes) to receive from a peer.
+  , tcpMaxReceiveLength :: Maybe Word32
   }
 
 -- | Internal functionality we expose for unit testing
@@ -588,6 +592,8 @@ defaultTCPParameters = TCPParameters {
   , tcpUserTimeout     = Nothing
   , tcpNewQDisc        = simpleUnboundedQDisc
   , transportConnectTimeout = Nothing
+  , tcpMaxAddressLength = Nothing
+  , tcpMaxReceiveLength = Nothing
   }
 
 --------------------------------------------------------------------------------
@@ -864,7 +870,9 @@ handleConnectionRequest transport sock = handle handleException $ do
     forM_ (tcpUserTimeout $ transportParams transport) $
       N.setSocketOption sock N.UserTimeout
     ourEndPointId <- recvWord32 sock
-    theirAddress  <- EndPointAddress . BS.concat <$> recvWithLength sock
+    let maxAddressLength = tcpMaxAddressLength $ transportParams transport
+    theirAddress  <- EndPointAddress . BS.concat <$>
+      recvWithLengthLimited maxAddressLength sock
     let ourAddress = encodeEndPointAddress (transportHost transport)
                                            (transportPort transport)
                                            ourEndPointId
@@ -914,7 +922,7 @@ handleConnectionRequest transport sock = handle handleException $ do
       -- been recorded as part of the remote endpoint. Either way, we no longer
       -- have to worry about closing the socket on receiving an asynchronous
       -- exception from this point forward.
-      forM_ mEndPoint $ handleIncomingMessages . (,) ourEndPoint
+      forM_ mEndPoint $ handleIncomingMessages (transportParams transport) . (,) ourEndPoint
 
     handleException :: SomeException -> IO ()
     handleException ex = do
@@ -957,8 +965,8 @@ handleConnectionRequest transport sock = handle handleException $ do
 --
 -- Returns only if the remote party closes the socket or if an error occurs.
 -- This runs in a thread that will never be killed.
-handleIncomingMessages :: EndPointPair -> IO ()
-handleIncomingMessages (ourEndPoint, theirEndPoint) = do
+handleIncomingMessages :: TCPParameters -> EndPointPair -> IO ()
+handleIncomingMessages params (ourEndPoint, theirEndPoint) = do
     mSock <- withMVar theirState $ \st ->
       case st of
         RemoteEndPointInvalid _ ->
@@ -1175,7 +1183,8 @@ handleIncomingMessages (ourEndPoint, theirEndPoint) = do
     -- overhead
     readMessage :: N.Socket -> LightweightConnectionId -> IO ()
     readMessage sock lcid =
-      recvWithLength sock >>= qdiscEnqueue' ourQueue theirAddr . Received (connId lcid)
+      recvWithLengthLimited recvLimit sock >>=
+        qdiscEnqueue' ourQueue theirAddr . Received (connId lcid)
 
     -- Stop probing a connection as a result of receiving a probe ack.
     stopProbing :: IO ()
@@ -1190,6 +1199,7 @@ handleIncomingMessages (ourEndPoint, theirEndPoint) = do
     ourQueue    = localQueue ourEndPoint
     theirState  = remoteState theirEndPoint
     theirAddr   = remoteAddress theirEndPoint
+    recvLimit   = tcpMaxReceiveLength params
 
     -- Deal with a premature exit
     prematureExit :: N.Socket -> IOException -> IO ()
@@ -1365,7 +1375,7 @@ setupRemoteEndPoint params (ourEndPoint, theirEndPoint) connTimeout = do
         return False
 
     when didAccept $ void $ forkIO $
-      handleIncomingMessages (ourEndPoint, theirEndPoint)
+      handleIncomingMessages params (ourEndPoint, theirEndPoint)
     return $ either (const Nothing) (Just . snd) result
   where
     ourAddress      = localAddress ourEndPoint

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -483,8 +483,14 @@ data TCPParameters = TCPParameters {
     -- | Create a QDisc for an EndPoint.
   , tcpNewQDisc :: forall t . IO (QDisc t)
     -- | Optional maximum length (in bytes) for a peer's address.
+    -- If a peer attempts to send an address of length exceeding the limit,
+    -- the connection will be refused (socket will close).
   , tcpMaxAddressLength :: Maybe Word32
     -- | Optional maximum length (in bytes) to receive from a peer.
+    -- If a peer attempts to send data on a lightweight connection exceeding
+    -- the limit, the heavyweight connection which carries that lightweight
+    -- connection will go down. The peer and the local node will get an
+    -- EventConnectionLost.
   , tcpMaxReceiveLength :: Maybe Word32
   }
 

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -55,7 +55,7 @@ import Network.Transport.TCP.Internal
   , encodeConnectionRequestResponse
   , decodeConnectionRequestResponse
   , forkServer
-  , recvWithLengthLimited
+  , recvWithLength
   , recvWord32
   , encodeWord32
   , tryCloseSocket
@@ -878,7 +878,7 @@ handleConnectionRequest transport sock = handle handleException $ do
     ourEndPointId <- recvWord32 sock
     let maxAddressLength = tcpMaxAddressLength $ transportParams transport
     theirAddress  <- EndPointAddress . BS.concat <$>
-      recvWithLengthLimited maxAddressLength sock
+      recvWithLength maxAddressLength sock
     let ourAddress = encodeEndPointAddress (transportHost transport)
                                            (transportPort transport)
                                            ourEndPointId
@@ -1189,7 +1189,7 @@ handleIncomingMessages params (ourEndPoint, theirEndPoint) = do
     -- overhead
     readMessage :: N.Socket -> LightweightConnectionId -> IO ()
     readMessage sock lcid =
-      recvWithLengthLimited recvLimit sock >>=
+      recvWithLength recvLimit sock >>=
         qdiscEnqueue' ourQueue theirAddr . Received (connId lcid)
 
     -- Stop probing a connection as a result of receiving a probe ack.

--- a/tests/TestTCP.hs
+++ b/tests/TestTCP.hs
@@ -17,6 +17,7 @@ import Network.Transport.TCP ( createTransport
                              , createTransportExposeInternals
                              , TransportInternals(..)
                              , encodeEndPointAddress
+                             , TCPParameters(..)
                              , defaultTCPParameters
                              , LightweightConnectionId
                              )
@@ -831,10 +832,77 @@ testUseRandomPort = do
      putMVar testDone ()
    takeMVar testDone
 
+-- | Verify that if a peer sends an address or data which exceeds the maximum
+--   length, that peer's connection will be terminated, but other peers will
+--   not be affected.
+testMaxLength :: IO ()
+testMaxLength = do
+
+  Right serverTransport <- createTransport "127.0.0.1" "9998" ((,) "127.0.0.1") $ defaultTCPParameters {
+      -- 17 bytes should fit every valid address at 127.0.0.1.
+      -- Port is at most 5 bytes (65536) and id is a base-10 Word32 so
+      -- at most 10 bytes. We'll have one client with a 5-byte port to push it
+      -- over the chosen limit of 16
+      tcpMaxAddressLength = Just 16
+    , tcpMaxReceiveLength = Just 8
+    }
+  Right goodClientTransport <- createTransport "127.0.0.1" "9999" ((,) "127.0.0.1") defaultTCPParameters
+  Right badClientTransport <- createTransport "127.0.0.1" "10000" ((,) "127.0.0.1") defaultTCPParameters
+
+  serverAddress <- newEmptyMVar
+  testDone <- newEmptyMVar
+  goodClientConnected <- newEmptyMVar
+  goodClientDone <- newEmptyMVar
+  badClientDone <- newEmptyMVar
+
+  forkTry $ do
+    Right serverEp <- newEndPoint serverTransport
+    putMVar serverAddress (address serverEp)
+    readMVar badClientDone
+    ConnectionOpened _ _ _ <- receive serverEp
+    Received _ _ <- receive serverEp
+    -- Will lose the connection when the good client sends 9 bytes.
+    ErrorEvent (TransportError (EventConnectionLost _) _) <- receive serverEp
+    readMVar goodClientDone
+    putMVar testDone ()
+
+  forkTry $ do
+    Right badClientEp <- newEndPoint badClientTransport
+    address <- readMVar serverAddress
+    -- Wait until the good client connects, then try to connect. It'll fail,
+    -- but the good client should still be OK.
+    readMVar goodClientConnected
+    Left (TransportError ConnectFailed _)
+      <- connect badClientEp address ReliableOrdered defaultConnectHints
+    closeEndPoint badClientEp
+    putMVar badClientDone ()
+
+  forkTry $ do
+    Right goodClientEp <- newEndPoint goodClientTransport
+    address <- readMVar serverAddress
+    Right conn <- connect goodClientEp address ReliableOrdered defaultConnectHints
+    putMVar goodClientConnected ()
+    -- Wait until the bad client has tried and failed to connect before
+    -- attempting a send, to ensure that its failure did not affect us.
+    readMVar badClientDone
+    Right () <- send conn ["00000000"]
+    -- The send which breaches the limit does not appear to fail, but the
+    -- (heavyweight) connection is now severed. We can reliably determine that
+    -- by receiving.
+    Right () <- send conn ["000000000"]
+    ErrorEvent (TransportError (EventConnectionLost _) _) <- receive goodClientEp
+    closeEndPoint goodClientEp
+    putMVar goodClientDone ()
+
+  readMVar testDone
+  closeTransport badClientTransport
+  closeTransport goodClientTransport
+  closeTransport serverTransport
+
 main :: IO ()
 main = do
   tcpResult <- tryIO $ runTests
-           [ ("Use random port"       , testUseRandomPort)
+           [ ("Use random port",        testUseRandomPort)
            , ("EarlyDisconnect",        testEarlyDisconnect)
            , ("EarlyCloseSocket",       testEarlyCloseSocket)
            , ("IgnoreCloseSocket",      testIgnoreCloseSocket)
@@ -847,6 +915,7 @@ main = do
            , ("Reconnect",              testReconnect)
            , ("UnidirectionalError",    testUnidirectionalError)
            , ("InvalidCloseConnection", testInvalidCloseConnection)
+           , ("MaxLength",              testMaxLength)
            ]
   -- Run the generic tests even if the TCP specific tests failed..
   testTransport (either (Left . show) (Right) <$>

--- a/tests/TestTCP.hs
+++ b/tests/TestTCP.hs
@@ -165,7 +165,7 @@ testEarlyDisconnect = do
       (clientPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO $ \sock -> do
         -- Initial setup
         0 <- recvWord32 sock
-        _ <- recvWithLength Nothing sock
+        _ <- recvWithLength maxBound sock
         sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestAccepted)]
 
         -- Server opens  a logical connection
@@ -174,7 +174,7 @@ testEarlyDisconnect = do
 
         -- Server sends a message
         1024 <- recvWord32 sock
-        ["ping"] <- recvWithLength Nothing sock
+        ["ping"] <- recvWithLength maxBound sock
 
         -- Reply
         sendMany sock [
@@ -277,7 +277,7 @@ testEarlyCloseSocket = do
       (clientPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO $ \sock -> do
         -- Initial setup
         0 <- recvWord32 sock
-        _ <- recvWithLength Nothing sock
+        _ <- recvWithLength maxBound sock
         sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestAccepted)]
 
         -- Server opens a logical connection
@@ -286,7 +286,7 @@ testEarlyCloseSocket = do
 
         -- Server sends a message
         1024 <- recvWord32 sock
-        ["ping"] <- recvWithLength Nothing sock
+        ["ping"] <- recvWithLength maxBound sock
 
         -- Reply
         sendMany sock [
@@ -620,7 +620,7 @@ testReconnect = do
   (serverPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO $ \sock -> do
     -- Accept the connection
     Right 0  <- tryIO $ recvWord32 sock
-    Right _  <- tryIO $ recvWithLength Nothing sock
+    Right _  <- tryIO $ recvWithLength maxBound sock
 
     -- The first time we close the socket before accepting the logical connection
     count <- modifyMVar counter $ \i -> return (i + 1, i)
@@ -639,7 +639,7 @@ testReconnect = do
           -- Client sends a message
           Right connId' <- tryIO $ (recvWord32 sock :: IO LightweightConnectionId)
           True <- return $ connId == connId'
-          Right ["ping"] <- tryIO $ recvWithLength Nothing sock
+          Right ["ping"] <- tryIO $ recvWithLength maxBound sock
           putMVar serverDone ()
 
     Right () <- tryIO $ N.sClose sock
@@ -712,7 +712,7 @@ testUnidirectionalError = do
     -- would shutdown the socket in the other direction)
     void . (try :: IO () -> IO (Either SomeException ())) $ do
       0 <- recvWord32 sock
-      _ <- recvWithLength Nothing sock
+      _ <- recvWithLength maxBound sock
       () <- sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestAccepted)]
 
       Just CreatedNewConnection <- decodeControlHeader <$> recvWord32 sock
@@ -720,7 +720,7 @@ testUnidirectionalError = do
 
       connId' <- recvWord32 sock :: IO LightweightConnectionId
       True <- return $ connId == connId'
-      ["ping"] <- recvWithLength Nothing sock
+      ["ping"] <- recvWithLength maxBound sock
       putMVar serverGotPing ()
 
   -- Client
@@ -843,8 +843,8 @@ testMaxLength = do
       -- Port is at most 5 bytes (65536) and id is a base-10 Word32 so
       -- at most 10 bytes. We'll have one client with a 5-byte port to push it
       -- over the chosen limit of 16
-      tcpMaxAddressLength = Just 16
-    , tcpMaxReceiveLength = Just 8
+      tcpMaxAddressLength = 16
+    , tcpMaxReceiveLength = 8
     }
   Right goodClientTransport <- createTransport "127.0.0.1" "9999" ((,) "127.0.0.1") defaultTCPParameters
   Right badClientTransport <- createTransport "127.0.0.1" "10000" ((,) "127.0.0.1") defaultTCPParameters


### PR DESCRIPTION
A transport has two optional limits:
- Address length: refuse to read peer addresses longer than this many bytes.
- Receive length: refuse to read data from a peer longer than this many bytes.
If a peer attempts to send an address of length exceeding the limit, the connection will be refused (socket will close).
If a peer attempts to send data on a lightweight connection exceeding the limit, the heavyweight connection which carries that lightweight connection will go down. The peer and the local node will get an `EventConnectionLost`.

A test case is included.

Some changes in here are also present in #51. Will resolves conflicts once either of them is merged.