### PR TITLE
Check peer-reported host against socket host

### DIFF
--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -91,6 +91,7 @@ import qualified Network.Socket as N
   , connect
   , sOMAXCONN
   , AddrInfo
+  , SockAddr(..)
   )
 
 #ifdef USE_MOCK_NETWORK
@@ -894,8 +895,8 @@ apiCloseEndPoint transport evs ourEndPoint =
 -- the transport down. We must be careful to close the socket when a (possibly
 -- asynchronous, ThreadKilled) exception occurs. (If an exception escapes from
 -- handleConnectionRequest the transport will be shut down.)
-handleConnectionRequest :: TCPTransport -> IO () -> N.Socket -> IO ()
-handleConnectionRequest transport socketClosed sock = handle handleException $ do
+handleConnectionRequest :: TCPTransport -> IO () -> (N.Socket, N.SockAddr) -> IO ()
+handleConnectionRequest transport socketClosed (sock, sockAddr) = handle handleException $ do
     when (tcpNoDelay $ transportParams transport) $
       N.setSocketOption sock N.NoDelay 1
     when (tcpKeepAlive $ transportParams transport) $

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -923,7 +923,13 @@ handleConnectionRequest transport socketClosed (sock, sockAddr) = handle handleE
       -- and we don't want to allow a peer to deny service to other peers by
       -- claiming to have their host and port.
       unless (theirHost == actualHost) $ do
-        throwIO (userError "handleConnectionRequest: reported host does not match actual host")
+        let errorString = concat [
+                "handleConnectionRequest: reported host "
+              , show theirHost
+              , " does not match actual host "
+              , show actualHost
+              ]
+        throwIO (userError errorString)
       return (ourEndPointId, theirAddress)
     addrInfo <- case mAddrInfo of
       Nothing -> throwIO (userError "handleConnectionRequest: timed out")

--- a/src/Network/Transport/TCP/Internal.hs
+++ b/src/Network/Transport/TCP/Internal.hs
@@ -178,7 +178,8 @@ forkServer :: N.HostName                     -- ^ Host
            -> (SomeException -> IO ())       -- ^ Termination handler. Called
                                              --   when the error handler throws
                                              --   an exception.
-           -> (IO () -> N.Socket -> IO ())   -- ^ Request handler. Gets an
+           -> (IO () -> (N.Socket, N.SockAddr) -> IO ())
+                                             -- ^ Request handler. Gets an
                                              --   action which completes when
                                              --   the socket is closed.
            -> IO (N.ServiceName, ThreadId)
@@ -202,7 +203,7 @@ forkServer host port backlog reuseAddr errorHandler terminationHandler requestHa
       let act restore (sock, sockAddr) = do
             socketClosed <- newEmptyMVar
             void $ forkIO $ restore $ do
-              requestHandler (readMVar socketClosed) sock
+              requestHandler (readMVar socketClosed) (sock, sockAddr)
               `finally`
               release ((sock, sockAddr), socketClosed)
 

--- a/src/Network/Transport/TCP/Internal.hs
+++ b/src/Network/Transport/TCP/Internal.hs
@@ -143,6 +143,8 @@ data ConnectionRequestResponse =
   | ConnectionRequestInvalid
     -- | /A/s request crossed with a request from /B/ (see protocols)
   | ConnectionRequestCrossed
+    -- | /A/ gave an incorrect host (did not match the host that /B/ observed).
+  | ConnectionRequestHostMismatch
   deriving (Show)
 
 decodeConnectionRequestResponse :: Word32 -> Maybe ConnectionRequestResponse
@@ -150,13 +152,15 @@ decodeConnectionRequestResponse w32 = case w32 of
   0 -> Just ConnectionRequestAccepted
   1 -> Just ConnectionRequestInvalid
   2 -> Just ConnectionRequestCrossed
+  3 -> Just ConnectionRequestHostMismatch
   _ -> Nothing
 
 encodeConnectionRequestResponse :: ConnectionRequestResponse -> Word32
 encodeConnectionRequestResponse crr = case crr of
-  ConnectionRequestAccepted -> 0
-  ConnectionRequestInvalid  -> 1
-  ConnectionRequestCrossed  -> 2
+  ConnectionRequestAccepted     -> 0
+  ConnectionRequestInvalid      -> 1
+  ConnectionRequestCrossed      -> 2
+  ConnectionRequestHostMismatch -> 3
 
 -- | Start a server at the specified address.
 --

--- a/tests/TestTCP.hs
+++ b/tests/TestTCP.hs
@@ -17,10 +17,10 @@ import Network.Transport.TCP ( createTransport
                              , createTransportExposeInternals
                              , TransportInternals(..)
                              , TCPParameters(..)
-                             , encodeEndPointAddress
-                             , decodeEndPointAddress
                              , defaultTCPParameters
                              , LightweightConnectionId
+                             , encodeEndPointAddress
+                             , decodeEndPointAddress
                              )
 import Control.Concurrent (threadDelay, killThread)
 import Control.Concurrent.MVar ( MVar
@@ -173,7 +173,7 @@ testEarlyDisconnect = do
       tlog "Client"
 
       -- Listen for incoming messages
-      (clientPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree sock -> do
+      (clientPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree (sock, _) -> do
         -- Initial setup
         0 <- recvWord32 sock
         _ <- recvWithLength maxBound sock
@@ -285,7 +285,7 @@ testEarlyCloseSocket = do
       tlog "Client"
 
       -- Listen for incoming messages
-      (clientPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree sock -> do
+      (clientPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree (sock, _) -> do
         -- Initial setup
         0 <- recvWord32 sock
         _ <- recvWithLength maxBound sock
@@ -638,8 +638,7 @@ testReconnect = do
   counter <- newMVar (0 :: Int)
 
   -- Server
-  (serverPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree sock -> do
-
+  (serverPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree (sock, _) -> do
     -- Accept the connection
     Right 0  <- tryIO $ recvWord32 sock
     Right _  <- tryIO $ recvWithLength maxBound sock
@@ -760,7 +759,7 @@ testUnidirectionalError = do
   serverGotPing <- newEmptyMVar
 
   -- Server
-  (serverPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree sock -> do
+  (serverPort, _) <- forkServer "127.0.0.1" "0" 5 True throwIO throwIO $ \socketFree (sock, _) -> do
     -- We accept connections, but when an exception occurs we don't do
     -- anything (in particular, we don't close the socket). This is important
     -- because when we shutdown one direction of the socket a recv here will

--- a/tests/TestTCP.hs
+++ b/tests/TestTCP.hs
@@ -1017,7 +1017,8 @@ testCheckPeerHost = do
 
   Left err <- connect ep2 (address ep1) ReliableOrdered defaultConnectHints
 
-  TransportError ConnectFailed "setupRemoteEndPoint: Host mismatch" <- return err
+  TransportError ConnectFailed "setupRemoteEndPoint: Host mismatch 127.0.0.1"
+    <- return err
 
   return ()
 


### PR DESCRIPTION
This is to prevent a peer from denying service to another peer by lying
about their end point address. The attacker would give the address
of the victim and then simply hold that heavyweight connection open, so
that requests by the victim would be rejected as crossed connections.