### PR TITLE
Protocol versioning (feature request with potential implementation)

### DIFF
--- a/network-transport-tcp.cabal
+++ b/network-transport-tcp.cabal
@@ -47,6 +47,7 @@ Test-Suite TestTCP
   Type:            exitcode-stdio-1.0
   Main-Is:         TestTCP.hs
   Build-Depends:   base >= 4.3 && < 5,
+                   bytestring >= 0.9 && < 0.11,
                    network-transport-tests >= 0.2.1.0 && < 0.3,
                    network >= 2.3 && < 2.7,
                    network-transport,

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -909,88 +909,10 @@ handleConnectionRequest transport socketClosed (sock, sockAddr) = handle handleE
       N.setSocketOption sock N.KeepAlive 1
     forM_ (tcpUserTimeout $ transportParams transport) $
       N.setSocketOption sock N.UserTimeout
-    -- Get the OS-determined host and port.
-    (actualHost, actualPort) <-
-      decodeSockAddr sockAddr >>=
-        maybe (throwIO (userError "handleConnectionRequest: invalid socket address")) return
-    let connTimeout = transportConnectTimeout (transportParams transport)
-    -- The peer must send our identifier and their address promptly, if a
-    -- timeout is set.
-    mAddrInfo <- maybe (fmap Just) System.Timeout.timeout connTimeout $ do
-      ourEndPointId <- recvWord32 sock
-      let maxAddressLength = tcpMaxAddressLength $ transportParams transport
-      theirAddress <- EndPointAddress . BS.concat <$>
-        recvWithLength maxAddressLength sock
-      return (ourEndPointId, theirAddress)
-    (ourEndPointId, theirAddress) <- case mAddrInfo of
-      Nothing -> throwIO (userError "handleConnectionRequest: timed out")
-      Just x -> return x
-    let ourAddress = encodeEndPointAddress (transportHost transport)
-                                           (transportPort transport)
-                                           ourEndPointId
-    (theirHost, _, _)
-      <- maybe (throwIO (userError "handleConnectionRequest: peer gave malformed address"))
-               return
-               (decodeEndPointAddress theirAddress)
-    let checkPeerHost = tcpCheckPeerHost (transportParams transport)
-    if checkPeerHost && (theirHost /= actualHost)
-    then
-      -- If the OS-determined host doesn't match the host that the peer gave us,
-      -- then we have no choice but to reject the connection. It's because we
-      -- use the EndPointAddress to key the remote end points (localConnections)
-      -- and we don't want to allow a peer to deny service to other peers by
-      -- claiming to have their host and port.
-      sendMany sock $
-          encodeWord32 (encodeConnectionRequestResponse ConnectionRequestHostMismatch)
-        : prependLength [BSC.pack actualHost]
-    else do
-      ourEndPoint <- withMVar (transportState transport) $ \st -> case st of
-        TransportValid vst ->
-          case vst ^. localEndPointAt ourAddress of
-            Nothing -> do
-              sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestInvalid)]
-              throwIO $ userError "handleConnectionRequest: Invalid endpoint"
-            Just ourEndPoint ->
-              return ourEndPoint
-        TransportClosed ->
-          throwIO $ userError "Transport closed"
-      void $ go ourEndPoint theirAddress
-  where
-    go :: LocalEndPoint -> EndPointAddress -> IO ()
-    go ourEndPoint theirAddress = do
-      -- This runs in a thread that will never be killed
-      mEndPoint <- handle ((>> return Nothing) . handleException) $ do
-        resetIfBroken ourEndPoint theirAddress
-        (theirEndPoint, isNew) <-
-          findRemoteEndPoint ourEndPoint theirAddress RequestedByThem Nothing
+    let handleVersioned = handleConnectionRequestV0 (sock, sockAddr)
+    handleVersioned
 
-        if not isNew
-          then do
-            void $ tryIO $ sendMany sock
-              [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestCrossed)]
-            probeIfValid theirEndPoint
-            return Nothing
-          else do
-            sendLock <- newMVar ()
-            let vst = ValidRemoteEndPointState
-                        {  remoteSocket        = sock
-                        ,  remoteSocketClosed  = socketClosed
-                        ,  remoteProbing       = Nothing
-                        ,  remoteSendLock      = sendLock
-                        , _remoteOutgoing      = 0
-                        , _remoteIncoming      = Set.empty
-                        , _remoteLastIncoming  = 0
-                        , _remoteNextConnOutId = firstNonReservedLightweightConnectionId
-                        }
-            sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestAccepted)]
-            resolveInit (ourEndPoint, theirEndPoint) (RemoteEndPointValid vst)
-            return (Just theirEndPoint)
-      -- If we left the scope of the exception handler with a return value of
-      -- Nothing then the socket is already closed; otherwise, the socket has
-      -- been recorded as part of the remote endpoint. Either way, we no longer
-      -- have to worry about closing the socket on receiving an asynchronous
-      -- exception from this point forward.
-      forM_ mEndPoint $ handleIncomingMessages (transportParams transport) . (,) ourEndPoint
+  where
 
     handleException :: SomeException -> IO ()
     handleException ex = do
@@ -999,33 +921,120 @@ handleConnectionRequest transport socketClosed (sock, sockAddr) = handle handleE
     rethrowIfAsync :: Maybe AsyncException -> IO ()
     rethrowIfAsync = mapM_ throwIO
 
-    probeIfValid :: RemoteEndPoint -> IO ()
-    probeIfValid theirEndPoint = modifyMVar_ (remoteState theirEndPoint) $
-      \st -> case st of
-        RemoteEndPointValid
-          vst@(ValidRemoteEndPointState { remoteProbing = Nothing }) -> do
-            tid <- forkIO $ do
-              -- send probe
-              let params = transportParams transport
-              void $ tryIO $ System.Timeout.timeout
-                  (maybe (-1) id $ transportConnectTimeout params) $ do
-                sendMany (remoteSocket vst)
-                  [encodeWord32 (encodeControlHeader ProbeSocket)]
-                threadDelay maxBound
-              -- Discard the connection if this thread is not killed (i.e. the
-              -- probe ack does not arrive on time).
-              --
-              -- The thread handling incoming messages will detect the socket is
-              -- closed and will report the failure upwards.
-              -- Waiting the probe ack and closing the socket is only needed in
-              -- platforms where TCP_USER_TIMEOUT is not available or when the
-              -- user does not set it. Otherwise the ack would be handled at the
-              -- TCP level and the the thread handling incoming messages would
-              -- get the error.
+    handleConnectionRequestV0 (sock, sockAddr) = do
+      -- Get the OS-determined host and port.
+      (actualHost, actualPort) <-
+        decodeSockAddr sockAddr >>=
+          maybe (throwIO (userError "handleConnectionRequest: invalid socket address")) return
+      let connTimeout = transportConnectTimeout (transportParams transport)
+      -- The peer must send our identifier and their address promptly, if a
+      -- timeout is set.
+      mAddrInfo <- maybe (fmap Just) System.Timeout.timeout connTimeout $ do
+        ourEndPointId <- recvWord32 sock
+        let maxAddressLength = tcpMaxAddressLength $ transportParams transport
+        theirAddress <- EndPointAddress . BS.concat <$>
+          recvWithLength maxAddressLength sock
+        return (ourEndPointId, theirAddress)
+      (ourEndPointId, theirAddress) <- case mAddrInfo of
+        Nothing -> throwIO (userError "handleConnectionRequest: timed out")
+        Just x -> return x
+      let ourAddress = encodeEndPointAddress (transportHost transport)
+                                             (transportPort transport)
+                                             ourEndPointId
+      (theirHost, _, _)
+        <- maybe (throwIO (userError "handleConnectionRequest: peer gave malformed address"))
+                 return
+                 (decodeEndPointAddress theirAddress)
+      let checkPeerHost = tcpCheckPeerHost (transportParams transport)
+      if checkPeerHost && (theirHost /= actualHost)
+      then
+        -- If the OS-determined host doesn't match the host that the peer gave us,
+        -- then we have no choice but to reject the connection. It's because we
+        -- use the EndPointAddress to key the remote end points (localConnections)
+        -- and we don't want to allow a peer to deny service to other peers by
+        -- claiming to have their host and port.
+        sendMany sock $
+            encodeWord32 (encodeConnectionRequestResponse ConnectionRequestHostMismatch)
+          : prependLength [BSC.pack actualHost]
+      else do
+        ourEndPoint <- withMVar (transportState transport) $ \st -> case st of
+          TransportValid vst ->
+            case vst ^. localEndPointAt ourAddress of
+              Nothing -> do
+                sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestInvalid)]
+                throwIO $ userError "handleConnectionRequest: Invalid endpoint"
+              Just ourEndPoint ->
+                return ourEndPoint
+          TransportClosed ->
+            throwIO $ userError "Transport closed"
+        void $ go ourEndPoint theirAddress
 
-            return $ RemoteEndPointValid
-              vst { remoteProbing = Just (killThread tid) }
-        _                       -> return st
+      where
+
+      go :: LocalEndPoint -> EndPointAddress -> IO ()
+      go ourEndPoint theirAddress = do
+        -- This runs in a thread that will never be killed
+        mEndPoint <- handle ((>> return Nothing) . handleException) $ do
+          resetIfBroken ourEndPoint theirAddress
+          (theirEndPoint, isNew) <-
+            findRemoteEndPoint ourEndPoint theirAddress RequestedByThem Nothing
+
+          if not isNew
+            then do
+              void $ tryIO $ sendMany sock
+                [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestCrossed)]
+              probeIfValid theirEndPoint
+              return Nothing
+            else do
+              sendLock <- newMVar ()
+              let vst = ValidRemoteEndPointState
+                          {  remoteSocket        = sock
+                          ,  remoteSocketClosed  = socketClosed
+                          ,  remoteProbing       = Nothing
+                          ,  remoteSendLock      = sendLock
+                          , _remoteOutgoing      = 0
+                          , _remoteIncoming      = Set.empty
+                          , _remoteLastIncoming  = 0
+                          , _remoteNextConnOutId = firstNonReservedLightweightConnectionId
+                          }
+              sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestAccepted)]
+              resolveInit (ourEndPoint, theirEndPoint) (RemoteEndPointValid vst)
+              return (Just theirEndPoint)
+        -- If we left the scope of the exception handler with a return value of
+        -- Nothing then the socket is already closed; otherwise, the socket has
+        -- been recorded as part of the remote endpoint. Either way, we no longer
+        -- have to worry about closing the socket on receiving an asynchronous
+        -- exception from this point forward.
+        forM_ mEndPoint $ handleIncomingMessages (transportParams transport) . (,) ourEndPoint
+
+      probeIfValid :: RemoteEndPoint -> IO ()
+      probeIfValid theirEndPoint = modifyMVar_ (remoteState theirEndPoint) $
+        \st -> case st of
+          RemoteEndPointValid
+            vst@(ValidRemoteEndPointState { remoteProbing = Nothing }) -> do
+              tid <- forkIO $ do
+                -- send probe
+                let params = transportParams transport
+                void $ tryIO $ System.Timeout.timeout
+                    (maybe (-1) id $ transportConnectTimeout params) $ do
+                  sendMany (remoteSocket vst)
+                    [encodeWord32 (encodeControlHeader ProbeSocket)]
+                  threadDelay maxBound
+                -- Discard the connection if this thread is not killed (i.e. the
+                -- probe ack does not arrive on time).
+                --
+                -- The thread handling incoming messages will detect the socket is
+                -- closed and will report the failure upwards.
+                tryCloseSocket (remoteSocket vst)
+                -- Waiting the probe ack and closing the socket is only needed in
+                -- platforms where TCP_USER_TIMEOUT is not available or when the
+                -- user does not set it. Otherwise the ack would be handled at the
+                -- TCP level and the the thread handling incoming messages would
+                -- get the error.
+
+              return $ RemoteEndPointValid
+                vst { remoteProbing = Just (killThread tid) }
+          _                       -> return st
 
 -- | Handle requests from a remote endpoint.
 --

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -63,6 +63,7 @@ import Network.Transport.TCP.Internal
   , EndPointId
   , encodeEndPointAddress
   , decodeEndPointAddress
+  , currentProtocolVersion
   )
 import Network.Transport.Internal
   ( prependLength
@@ -1941,7 +1942,7 @@ socketToEndPoint (EndPointAddress ourAddress) theirAddress reuseAddr noDelay kee
         mapIOException failed $ do
           sendMany sock $
               -- The version.
-              encodeWord32 0x000000
+              encodeWord32 currentProtocolVersion
               -- The V0 handshake data with the length prepended.
             : prependLength (encodeWord32 theirEndPointId : prependLength [ourAddress])
           recvWord32 sock

--- a/src/Network/Transport/TCP/Internal.hs
+++ b/src/Network/Transport/TCP/Internal.hs
@@ -18,6 +18,7 @@ module Network.Transport.TCP.Internal
   , encodeEndPointAddress
   , decodeEndPointAddress
   , ProtocolVersion
+  , currentProtocolVersion
   ) where
 
 #if ! MIN_VERSION_base(4,6,0)
@@ -101,10 +102,13 @@ import qualified Data.ByteString.Char8 as BSC (unpack, pack)
 -- | Local identifier for an endpoint within this transport
 type EndPointId = Word32
 
--- | Identifies the version of the network-transport-protocol.
+-- | Identifies the version of the network-transport-tcp protocol.
 -- It's the first piece of data sent when a new heavyweight connection is
 -- established.
 type ProtocolVersion = Word32
+
+currentProtocolVersion :: ProtocolVersion
+currentProtocolVersion = 0x00000000
 
 -- | Control headers
 data ControlHeader =
@@ -143,7 +147,7 @@ encodeControlHeader ch = case ch of
 
 -- | Response sent by /B/ to /A/ when /A/ tries to connect
 data ConnectionRequestResponse =
-    -- | /B/ does not support the version requested by /A/.
+    -- | /B/ does not support the protocol version requested by /A/.
     ConnectionRequestUnsupportedVersion
     -- | /B/ accepts the connection
   | ConnectionRequestAccepted

--- a/tests/TestTCP.hs
+++ b/tests/TestTCP.hs
@@ -989,7 +989,12 @@ testCloseEndPoint = do
     sock <- N.socket (N.addrFamily addr) N.Stream N.defaultProtocol
     N.connect sock (N.addrAddress addr)
     sendMany sock [
-        encodeWord32 endPointId
+        -- First send the version and length of the handshake.
+        -- 4 bytes for the endpoint id, 13 for the address.
+        encodeWord32 0x00000000
+      , encodeWord32 17
+        -- Version 0x00000000 handshake data.
+      , encodeWord32 endPointId
       , encodeWord32 13
       , "127.0.0.1:0:0"
       -- Create a lightweight connection.

--- a/tests/TestTCP.hs
+++ b/tests/TestTCP.hs
@@ -84,6 +84,7 @@ import Network.Transport.TCP.Mock.Socket.ByteString (sendMany)
 import Network.Socket.ByteString (sendMany)
 #endif
 
+import qualified Data.ByteString as BS (length, concat)
 import Data.String (fromString)
 import GHC.IO.Exception (ioe_errno)
 import Foreign.C.Error (Errno(..), eADDRNOTAVAIL)
@@ -988,19 +989,25 @@ testCloseEndPoint = do
     addr:_ <- N.getAddrInfo (Just N.defaultHints) (Just hostName) (Just serviceName)
     sock <- N.socket (N.addrFamily addr) N.Stream N.defaultProtocol
     N.connect sock (N.addrAddress addr)
-    sendMany sock [
-        -- First send the version and length of the handshake.
-        -- 4 bytes for the endpoint id, 13 for the address.
-        encodeWord32 0x00000000
-      , encodeWord32 17
+    let endPointAddress = "127.0.0.1:0:0"
         -- Version 0x00000000 handshake data.
-      , encodeWord32 endPointId
-      , encodeWord32 13
-      , "127.0.0.1:0:0"
-      -- Create a lightweight connection.
-      , encodeWord32 (encodeControlHeader CreatedNewConnection)
-      , encodeWord32 1024
-      ]
+        v0handshake = [
+            encodeWord32 endPointId
+          , encodeWord32 (fromIntegral (BS.length endPointAddress))
+          , endPointAddress
+          ]
+        -- Version, and total length of the versioned handshake.
+        handshake = [
+            encodeWord32 0x00000000
+          , encodeWord32 (fromIntegral (BS.length (BS.concat v0handshake)))
+          ]
+    sendMany sock $
+         handshake
+      ++ v0handshake
+      ++ [ -- Create a lightweight connection.
+           encodeWord32 (encodeControlHeader CreatedNewConnection)
+         , encodeWord32 1024
+         ]
     readMVar serverFinished
     N.close sock
 


### PR DESCRIPTION
A candidate implementation of protocol versioning. Here's how it works:

Versionless part of the protocol:

- When `A` connects to `B` it always sends a `Word32` version identifier
  followed by a `Word32` giving the length of remaining data (presumably
  version-specific handshake data).
- `B` can request a different version by sending
  `ConnectionRequestUnsupportedVersion` followed by a `Word32`
  indicating the version which `B` would prefer to use. Since it has the
  length of the remaining data, it can then read and discard the rest of
  the data sent by `A`.
- `A` can try again using `B`'s preferred version, or abandon the
  connection if it doesn't support that version.

If `B` accepts the version number, then the rest of the interaction
proceeds according to that version.

Currently there is only version `0x00000000`. Any connection with a
different version number will be rejected as unsupported, and any
rejected connection attempt will abandoned because this version of
nt-tcp supports only `0x00000000`.

It's important to note that there's minimal performance penalty for
the typical Cloud Haskell use case, where every peer runs the same
version. The versionless part of the protocol is optimistic: the connecting
peer assumes its peer will be able to handle its version, and extra round
trips are imposed only if the peer needs a downgrade/upgrade.

Thoughts?