### PR TITLE
Unaddressable transports/endpoints (behind NAT, for instance)

### DIFF
--- a/network-transport-tcp.cabal
+++ b/network-transport-tcp.cabal
@@ -30,7 +30,8 @@ Library
                    data-accessor >= 0.2 && < 0.3,
                    containers >= 0.4 && < 0.6,
                    bytestring >= 0.9 && < 0.11,
-                   network >= 2.6.2 && < 2.7
+                   network >= 2.6.2 && < 2.7,
+                   uuid >= 1.3 && < 1.4
   Exposed-modules: Network.Transport.TCP,
                    Network.Transport.TCP.Internal
   Default-Extensions: CPP

--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -18,6 +18,9 @@
 module Network.Transport.TCP
   ( -- * Main API
     createTransport
+  , TCPAddr(..)
+  , defaultTCPAddr
+  , TCPAddrInfo(..)
   , TCPParameters(..)
   , defaultTCPParameters
     -- * Internals (exposed for unit tests)
@@ -64,6 +67,7 @@ import Network.Transport.TCP.Internal
   , encodeEndPointAddress
   , decodeEndPointAddress
   , currentProtocolVersion
+  , randomEndPointAddress
   )
 import Network.Transport.Internal
   ( prependLength
@@ -145,7 +149,7 @@ import Control.Exception
   )
 import Data.IORef (IORef, newIORef, writeIORef, readIORef, writeIORef)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS (concat)
+import qualified Data.ByteString as BS (concat, length, null)
 import qualified Data.ByteString.Char8 as BSC (pack, unpack)
 import Data.Bits (shiftL, (.|.))
 import Data.Maybe (isJust)
@@ -167,7 +171,6 @@ import Data.Accessor (Accessor, accessor, (^.), (^=), (^:))
 import qualified Data.Accessor.Container as DAC (mapMaybe)
 import Data.Foldable (forM_, mapM_)
 import qualified System.Timeout (timeout)
-import qualified Data.ByteString as BS (length)
 
 -- $design
 --
@@ -280,11 +283,21 @@ import qualified Data.ByteString as BS (length)
 --   about the state (ValidTransportState, ValidLocalEndPointState,
 --   ValidRemoteEndPointState).
 
-data TCPTransport = TCPTransport
+-- | Information about the network addresses of a transport: the external
+-- host/port as well as the bound host/port, which are not necessarily the
+-- same.
+data TransportAddrInfo = TransportAddrInfo
   { transportHost     :: !N.HostName
   , transportPort     :: !N.ServiceName
   , transportBindHost :: !N.HostName
   , transportBindPort :: !N.ServiceName
+  }
+
+data TCPTransport = TCPTransport
+  { transportAddrInfo :: !(Maybe TransportAddrInfo)
+    -- ^ This is 'Nothing' in case the transport is not addressable from the
+    -- network: peers cannot connect to it unless it has a connection to the
+    -- peer.
   , transportState    :: !(MVar TransportState)
   , transportParams   :: !TCPParameters
   }
@@ -294,16 +307,17 @@ data TransportState =
   | TransportClosed
 
 data ValidTransportState = ValidTransportState
-  { _localEndPoints :: !(Map EndPointAddress LocalEndPoint)
+  { _localEndPoints :: !(Map EndPointId LocalEndPoint)
   , _nextEndPointId :: !EndPointId
   }
 
 data LocalEndPoint = LocalEndPoint
-  { localAddress :: !EndPointAddress
-  , localState   :: !(MVar LocalEndPointState)
+  { localAddress    :: !EndPointAddress
+  , localEndPointId :: !EndPointId
+  , localState      :: !(MVar LocalEndPointState)
     -- | A 'QDisc' is held here rather than on the 'ValidLocalEndPointState'
     --   because even closed 'LocalEndPoint's can have queued input data.
-  , localQueue   :: !(QDisc Event)
+  , localQueue      :: !(QDisc Event)
   }
 
 data LocalEndPointState =
@@ -464,6 +478,28 @@ type LightweightConnectionId = Word32
 -- 'LightweightConnectionId'.
 type HeavyweightConnectionId = Word32
 
+-- | A transport which is addressable from the network must give a host/port
+-- on which to bind/listen, and determine its external address (host/port) from
+-- the actual port (which may not be known, in case 0 is used for the bind
+-- port).
+data TCPAddrInfo = TCPAddrInfo {
+    tcpBindHost :: N.HostName
+  , tcpBindPort :: N.ServiceName
+  , tcpExternalAddress :: N.ServiceName -> (N.HostName, N.ServiceName)
+  }
+
+-- | Addressability of a transport. If your transport cannot be connected
+-- to, for instance because it runs behind NAT, use Unaddressable.
+data TCPAddr = Addressable TCPAddrInfo | Unaddressable
+
+-- | The bind and external host/port are the same.
+defaultTCPAddr :: N.HostName -> N.ServiceName -> TCPAddr
+defaultTCPAddr host port = Addressable $ TCPAddrInfo {
+    tcpBindHost = host
+  , tcpBindPort = port
+  , tcpExternalAddress = (,) host
+  }
+
 -- | Parameters for setting up the TCP transport
 data TCPParameters = TCPParameters {
     -- | Backlog for 'listen'.
@@ -518,7 +554,7 @@ data TCPParameters = TCPParameters {
 -- | Internal functionality we expose for unit testing
 data TransportInternals = TransportInternals
   { -- | The ID of the thread that listens for new incoming connections
-    transportThread     :: ThreadId
+    transportThread     :: Maybe ThreadId
     -- | A variant of newEndPoint in which the QDisc determined by the
     -- transport's TCPParameters can be optionally overridden.
   , newEndPointInternal :: (forall t . Maybe (QDisc t))
@@ -534,74 +570,79 @@ data TransportInternals = TransportInternals
 --------------------------------------------------------------------------------
 
 -- | Create a TCP transport
-createTransport :: N.HostName    -- ^ Bind host name.
-                -> N.ServiceName -- ^ Bind port.
-                -> (N.ServiceName -> (N.HostName, N.ServiceName))
-                   -- ^ External address host name and port, computed from the
-                   --   actual bind port.
-                -> TCPParameters
-                -> IO (Either IOException Transport)
-createTransport bindHost bindPort mkExternal params =
-  either Left (Right . fst) <$>
-    createTransportExposeInternals bindHost bindPort mkExternal params
+createTransport
+  :: TCPAddr
+  -> TCPParameters
+  -> IO (Either IOException Transport)
+createTransport addr params =
+  either Left (Right . fst) <$> createTransportExposeInternals addr params
 
 -- | You should probably not use this function (used for unit testing only)
 createTransportExposeInternals
-  :: N.HostName
-  -> N.ServiceName
-  -> (N.ServiceName -> (N.HostName, N.ServiceName))
+  :: TCPAddr
   -> TCPParameters
   -> IO (Either IOException (Transport, TransportInternals))
-createTransportExposeInternals bindHost bindPort mkExternal params = do
+createTransportExposeInternals addr params = do
     state <- newMVar . TransportValid $ ValidTransportState
       { _localEndPoints = Map.empty
       , _nextEndPointId = 0
       }
-    tryIO $ mdo
-       when ( isJust (tcpUserTimeout params) &&
-              not (N.isSupportedSocketOption N.UserTimeout)
-            ) $
-         throwIO $ userError $ "Network.Transport.TCP.createTransport: " ++
-                               "the parameter tcpUserTimeout is unsupported " ++
-                               "in this system."
-       -- We don't know for sure the actual port 'forkServer' binded until it
-       -- completes (see description of 'forkServer'), yet we need the port to
-       -- construct a transport. So we tie a recursive knot.
-       (port', result) <- do
-         let (externalHost, externalPort) = mkExternal port'
-         let transport = TCPTransport { transportState    = state
-                                      , transportHost     = externalHost
-                                      , transportPort     = externalPort
-                                      , transportBindHost = bindHost
-                                      , transportBindPort = port'
-                                      , transportParams   = params
-                                      }
-         bracketOnError (forkServer
-                             bindHost
-                             bindPort
-                             (tcpBacklog params)
-                             (tcpReuseServerAddr params)
-                             (errorHandler transport)
-                             (terminationHandler transport)
-                             (handleConnectionRequest transport))
-                      (\(_port', tid) -> killThread tid)
-                      (\(port'', tid) -> (port'',) <$> mkTransport transport tid)
-       return result
+    case addr of
+
+      Unaddressable ->
+        let transport = TCPTransport { transportState    = state
+                                     , transportAddrInfo = Nothing
+                                     , transportParams   = params
+                                     }
+        in  fmap Right (mkTransport transport Nothing)
+
+      Addressable (TCPAddrInfo bindHost bindPort mkExternal) -> tryIO $ mdo
+        when ( isJust (tcpUserTimeout params) &&
+               not (N.isSupportedSocketOption N.UserTimeout)
+             ) $
+          throwIO $ userError $ "Network.Transport.TCP.createTransport: " ++
+                                "the parameter tcpUserTimeout is unsupported " ++
+                                "in this system."
+        -- We don't know for sure the actual port 'forkServer' binded until it
+        -- completes (see description of 'forkServer'), yet we need the port to
+        -- construct a transport. So we tie a recursive knot.
+        (port', result) <- do
+          let (externalHost, externalPort) = mkExternal port'
+          let addrInfo = TransportAddrInfo { transportHost     = externalHost
+                                           , transportPort     = externalPort
+                                           , transportBindHost = bindHost
+                                           , transportBindPort = port'
+                                           }
+          let transport = TCPTransport { transportState    = state
+                                       , transportAddrInfo = Just addrInfo
+                                       , transportParams   = params
+                                       }
+          bracketOnError (forkServer
+                              bindHost
+                              bindPort
+                              (tcpBacklog params)
+                              (tcpReuseServerAddr params)
+                              (errorHandler transport)
+                              (terminationHandler transport)
+                              (handleConnectionRequest transport))
+                       (\(_port', tid) -> killThread tid)
+                       (\(port'', tid) -> (port'',) <$> mkTransport transport (Just tid))
+        return result
   where
     mkTransport :: TCPTransport
-                -> ThreadId
+                -> Maybe ThreadId
                 -> IO (Transport, TransportInternals)
-    mkTransport transport tid = do
+    mkTransport transport mtid = do
       return
         ( Transport
             { newEndPoint = do
                 qdisc <- tcpNewQDisc params
                 apiNewEndPoint transport qdisc
             , closeTransport = let evs = [ EndPointClosed ]
-                               in apiCloseTransport transport (Just tid) evs
+                               in apiCloseTransport transport mtid evs
             }
         , TransportInternals
-            { transportThread     = tid
+            { transportThread     = mtid
             , socketBetween       = internalSocketBetween transport
             , newEndPointInternal = \mqdisc -> case mqdisc of
                 Just qdisc -> apiNewEndPoint transport qdisc
@@ -665,7 +706,7 @@ apiNewEndPoint transport qdisc =
     return EndPoint
       { receive       = qdiscDequeue (localQueue ourEndPoint)
       , address       = localAddress ourEndPoint
-      , connect       = apiConnect (transportParams transport) ourEndPoint
+      , connect       = apiConnect transport ourEndPoint
       , closeEndPoint = let evs = [ EndPointClosed ]
                         in  apiCloseEndPoint transport evs ourEndPoint
       , newMulticastGroup     = return . Left $ newMulticastGroupError
@@ -747,20 +788,20 @@ simpleOnePlaceQDisc = do
     }
 
 -- | Connnect to an endpoint
-apiConnect :: TCPParameters    -- ^ Parameters
+apiConnect :: TCPTransport
            -> LocalEndPoint    -- ^ Local end point
            -> EndPointAddress  -- ^ Remote address
            -> Reliability      -- ^ Reliability (ignored)
            -> ConnectHints     -- ^ Hints
            -> IO (Either (TransportError ConnectErrorCode) Connection)
-apiConnect params ourEndPoint theirAddress _reliability hints =
+apiConnect transport ourEndPoint theirAddress _reliability hints =
   try . asyncWhenCancelled close $
     if localAddress ourEndPoint == theirAddress
       then connectToSelf ourEndPoint
       else do
         resetIfBroken ourEndPoint theirAddress
         (theirEndPoint, connId) <-
-          createConnectionTo params ourEndPoint theirAddress hints
+          createConnectionTo transport ourEndPoint theirAddress hints
         -- connAlive can be an IORef rather than an MVar because it is protected
         -- by the remoteState MVar. We don't need the overhead of locking twice.
         connAlive <- newIORef True
@@ -768,6 +809,8 @@ apiConnect params ourEndPoint theirAddress _reliability hints =
           { send  = apiSend  (ourEndPoint, theirEndPoint) connId connAlive
           , close = apiClose (ourEndPoint, theirEndPoint) connId connAlive
           }
+  where
+  params = transportParams transport
 
 -- | Close a connection
 apiClose :: EndPointPair -> LightweightConnectionId -> IORef Bool -> IO ()
@@ -967,37 +1010,46 @@ handleConnectionRequest transport socketClosed (sock, sockAddr) = handle handleE
       (numericHost, resolvedHost, actualPort) <-
         resolveSockAddr sockAddr >>=
           maybe (throwIO (userError "handleConnectionRequest: invalid socket address")) return
-
-      (ourEndPointId, theirAddress) <- do
+      -- The peer must send our identifier and their address promptly, if a
+      -- timeout is set.
+      addrInfo <- do
         ourEndPointId <- recvWord32 sock
         let maxAddressLength = tcpMaxAddressLength $ transportParams transport
-        theirAddress <- EndPointAddress . BS.concat <$>
-          recvWithLength maxAddressLength sock
-        return (ourEndPointId, theirAddress)
-      let ourAddress = encodeEndPointAddress (transportHost transport)
-                                             (transportPort transport)
-                                             ourEndPointId
-      (theirHost, _, _)
-        <- maybe (throwIO (userError "handleConnectionRequest: peer gave malformed address"))
-                 return
-                 (decodeEndPointAddress theirAddress)
+        mTheirAddress <- BS.concat <$> recvWithLength maxAddressLength sock
+        -- Sending a length = 0 address means unaddressable.
+        if BS.null mTheirAddress
+        then fmap ((,) ourEndPointId . Left) randomEndPointAddress
+        else do
+          let theirAddress = EndPointAddress mTheirAddress
+          (theirHost, theirPort, theirEndPointId)
+            <- maybe (throwIO (userError "handleConnectionRequest: peer gave malformed address"))
+                     return
+                     (decodeEndPointAddress theirAddress)
+          return (ourEndPointId, Right (theirAddress, (theirHost, theirPort, theirEndPointId)))
+      (ourEndPointId, theirAddress, peerHost) <- case addrInfo of
+        (x, Left y) -> return (x, y, Nothing)
+        (x, Right (y, (h, _, _))) -> return (x, y, Just h)
       let checkPeerHost = tcpCheckPeerHost (transportParams transport)
-      if checkPeerHost && (theirHost /= resolvedHost) && (theirHost /= numericHost)
+      continue <- case (peerHost, checkPeerHost) of
+        (Just theirHost, True) -> do
+          -- If the OS-determined host doesn't match the host that the peer gave us,
+          -- then we have no choice but to reject the connection. It's because we
+          -- use the EndPointAddress to key the remote end points (localConnections)
+          -- and we don't want to allow a peer to deny service to other peers by
+          -- claiming to have their host and port.
+          if theirHost == numericHost || theirHost == resolvedHost
+          then return True
+          else do
+            sendMany sock $
+                encodeWord32 (encodeConnectionRequestResponse ConnectionRequestHostMismatch)
+              : (prependLength [BSC.pack theirHost] ++ prependLength [BSC.pack numericHost] ++ prependLength [BSC.pack resolvedHost])
+            return False
+        _ -> return True
+      if continue
       then do
-        -- If the OS-determined host doesn't match the host that the peer gave us,
-        -- then we have no choice but to reject the connection. It's because we
-        -- use the EndPointAddress to key the remote end points (localConnections)
-        -- and we don't want to allow a peer to deny service to other peers by
-        -- claiming to have their host and port.
-        sendMany sock $
-            encodeWord32 (encodeConnectionRequestResponse ConnectionRequestHostMismatch)
-          : (prependLength [BSC.pack theirHost] ++ prependLength [BSC.pack numericHost] ++ prependLength [BSC.pack resolvedHost])
-
-        return Nothing
-      else do
         ourEndPoint <- withMVar (transportState transport) $ \st -> case st of
           TransportValid vst ->
-            case vst ^. localEndPointAt ourAddress of
+            case vst ^. localEndPointAt ourEndPointId of
               Nothing -> do
                 sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestInvalid)]
                 throwIO $ userError "handleConnectionRequest: Invalid endpoint"
@@ -1006,11 +1058,13 @@ handleConnectionRequest transport socketClosed (sock, sockAddr) = handle handleE
           TransportClosed ->
             throwIO $ userError "Transport closed"
         return (Just (go ourEndPoint theirAddress))
+      else return Nothing
 
       where
 
       go :: LocalEndPoint -> EndPointAddress -> IO ()
       go ourEndPoint theirAddress = handle handleException $ do
+
         resetIfBroken ourEndPoint theirAddress
         (theirEndPoint, isNew) <-
           findRemoteEndPoint ourEndPoint theirAddress RequestedByThem Nothing
@@ -1409,12 +1463,13 @@ handleIncomingMessages params (ourEndPoint, theirEndPoint) =
 -- block until that is resolved.
 --
 -- May throw a TransportError ConnectErrorCode exception.
-createConnectionTo :: TCPParameters
-                    -> LocalEndPoint
-                    -> EndPointAddress
-                    -> ConnectHints
-                    -> IO (RemoteEndPoint, LightweightConnectionId)
-createConnectionTo params ourEndPoint theirAddress hints = do
+createConnectionTo
+  :: TCPTransport
+  -> LocalEndPoint
+  -> EndPointAddress
+  -> ConnectHints
+  -> IO (RemoteEndPoint, LightweightConnectionId)
+createConnectionTo transport ourEndPoint theirAddress hints = do
     -- @timer@ is an IO action that completes when the timeout expires.
     timer <- case connTimeout of
               Just t -> do
@@ -1426,6 +1481,7 @@ createConnectionTo params ourEndPoint theirAddress hints = do
 
   where
 
+    params = transportParams transport
     connTimeout = connectTimeout hints `mplus` transportConnectTimeout params
 
     -- The second argument indicates the response obtained to the last
@@ -1446,7 +1502,7 @@ createConnectionTo params ourEndPoint theirAddress hints = do
       if isNew
         then do
           mr' <- handle (absorbAllExceptions Nothing) $
-            setupRemoteEndPoint params (ourEndPoint, theirEndPoint) connTimeout
+            setupRemoteEndPoint transport (ourEndPoint, theirEndPoint) connTimeout
           go timer (fmap ((,) theirEndPoint) mr')
         else do
           -- 'findRemoteEndPoint' will have increased 'remoteOutgoing'
@@ -1486,10 +1542,14 @@ createConnectionTo params ourEndPoint theirAddress hints = do
       return a
 
 -- | Set up a remote endpoint
-setupRemoteEndPoint :: TCPParameters -> EndPointPair -> Maybe Int
-                    -> IO (Maybe ConnectionRequestResponse)
-setupRemoteEndPoint params (ourEndPoint, theirEndPoint) connTimeout = do
-    result <- socketToEndPoint ourAddress
+setupRemoteEndPoint
+  :: TCPTransport
+  -> EndPointPair
+  -> Maybe Int
+  -> IO (Maybe ConnectionRequestResponse)
+setupRemoteEndPoint transport (ourEndPoint, theirEndPoint) connTimeout = do
+    let mOurAddress = const ourAddress <$> transportAddrInfo transport
+    result <- socketToEndPoint mOurAddress
                                theirAddress
                                (tcpReuseClientAddr params)
                                (tcpNoDelay params)
@@ -1571,6 +1631,7 @@ setupRemoteEndPoint params (ourEndPoint, theirEndPoint) connTimeout = do
       (tryCloseSocket sock `finally` putMVar socketClosed ())
     return $ either (const Nothing) (Just . (\(_,_,x) -> x)) result
   where
+    params          = transportParams transport
     ourAddress      = localAddress ourEndPoint
     theirAddress    = remoteAddress theirEndPoint
     invalidAddress  = TransportError ConnectNotFound
@@ -1717,15 +1778,19 @@ createLocalEndPoint transport qdisc = do
     modifyMVar (transportState transport) $ \st -> case st of
       TransportValid vst -> do
         let ix   = vst ^. nextEndPointId
-        let addr = encodeEndPointAddress (transportHost transport)
-                                         (transportPort transport)
-                                         ix
-        let localEndPoint = LocalEndPoint { localAddress = addr
-                                          , localQueue   = qdisc
-                                          , localState   = state
+        addr <- case transportAddrInfo transport of
+          Nothing -> randomEndPointAddress
+          Just addrInfo -> return $
+            encodeEndPointAddress (transportHost addrInfo)
+                                  (transportPort addrInfo)
+                                  ix
+        let localEndPoint = LocalEndPoint { localAddress    = addr
+                                          , localEndPointId = ix
+                                          , localQueue      = qdisc
+                                          , localState      = state
                                           }
         return ( TransportValid
-               . (localEndPointAt addr ^= Just localEndPoint)
+               . (localEndPointAt ix ^= Just localEndPoint)
                . (nextEndPointId ^= ix + 1)
                $ vst
                , localEndPoint
@@ -1766,7 +1831,7 @@ removeLocalEndPoint transport ourEndPoint =
   modifyMVar_ (transportState transport) $ \st -> case st of
     TransportValid vst ->
       return ( TransportValid
-             . (localEndPointAt (localAddress ourEndPoint) ^= Nothing)
+             . (localEndPointAt (localEndPointId ourEndPoint) ^= Nothing)
              $ vst
              )
     TransportClosed ->
@@ -1949,16 +2014,16 @@ withScheduledAction ourEndPoint f =
 -- responsible for eventually closing the socket and filling the MVar (which
 -- is empty). The MVar must be filled immediately after, and never before,
 -- the socket is closed.
-socketToEndPoint :: EndPointAddress -- ^ Our address
-                 -> EndPointAddress -- ^ Their address
-                 -> Bool            -- ^ Use SO_REUSEADDR?
-                 -> Bool            -- ^ Use TCP_NODELAY
-                 -> Bool            -- ^ Use TCP_KEEPALIVE
-                 -> Maybe Int       -- ^ Maybe TCP_USER_TIMEOUT
-                 -> Maybe Int       -- ^ Timeout for connect
+socketToEndPoint :: Maybe EndPointAddress -- ^ Our address
+                 -> EndPointAddress       -- ^ Their address
+                 -> Bool                  -- ^ Use SO_REUSEADDR?
+                 -> Bool                  -- ^ Use TCP_NODELAY
+                 -> Bool                  -- ^ Use TCP_KEEPALIVE
+                 -> Maybe Int             -- ^ Maybe TCP_USER_TIMEOUT
+                 -> Maybe Int             -- ^ Timeout for connect
                  -> IO (Either (TransportError ConnectErrorCode)
                                (MVar (), N.Socket, ConnectionRequestResponse))
-socketToEndPoint (EndPointAddress ourAddress) theirAddress reuseAddr noDelay keepAlive
+socketToEndPoint mOurAddress theirAddress reuseAddr noDelay keepAlive
                  mUserTimeout timeout =
   try $ do
     (host, port, theirEndPointId) <- case decodeEndPointAddress theirAddress of
@@ -1979,11 +2044,15 @@ socketToEndPoint (EndPointAddress ourAddress) theirAddress reuseAddr noDelay kee
         mapIOException invalidAddress $
           N.connect sock (N.addrAddress addr)
         mapIOException failed $ do
-          sendMany sock $
-              -- The version.
-              encodeWord32 currentProtocolVersion
-              -- The V0 handshake data with the length prepended.
-            : prependLength (encodeWord32 theirEndPointId : prependLength [ourAddress])
+          case mOurAddress of
+            Just (EndPointAddress ourAddress) ->
+              sendMany sock $
+                  encodeWord32 currentProtocolVersion
+                : prependLength (encodeWord32 theirEndPointId : prependLength [ourAddress])
+            Nothing ->
+              sendMany sock $
+                  encodeWord32 currentProtocolVersion
+                : prependLength ([encodeWord32 theirEndPointId, encodeWord32 0])
           recvWord32 sock
       case decodeConnectionRequestResponse response of
         Nothing -> throwIO (failed . userError $ "Unexpected response")
@@ -2019,11 +2088,14 @@ internalSocketBetween :: TCPTransport    -- ^ Transport
                       -> EndPointAddress -- ^ Remote endpoint
                       -> IO N.Socket
 internalSocketBetween transport ourAddress theirAddress = do
+  ourEndPointId <- case decodeEndPointAddress ourAddress of
+    Just (_, _, eid) -> return eid
+    _ -> throwIO $ userError "Malformed local EndPointAddress"
   ourEndPoint <- withMVar (transportState transport) $ \st -> case st of
       TransportClosed ->
         throwIO $ userError "Transport closed"
       TransportValid vst ->
-        case vst ^. localEndPointAt ourAddress of
+        case vst ^. localEndPointAt ourEndPointId of
           Nothing -> throwIO $ userError "Local endpoint not found"
           Just ep -> return ep
   theirEndPoint <- withMVar (localState ourEndPoint) $ \st -> case st of
@@ -2046,6 +2118,7 @@ internalSocketBetween transport ourAddress theirAddress = do
       throwIO err
     RemoteEndPointFailed err ->
       throwIO err
+  where
 
 --------------------------------------------------------------------------------
 -- Constants                                                                  --
@@ -2067,7 +2140,7 @@ firstNonReservedHeavyweightConnectionId = 1
 -- Accessor definitions                                                       --
 --------------------------------------------------------------------------------
 
-localEndPoints :: Accessor ValidTransportState (Map EndPointAddress LocalEndPoint)
+localEndPoints :: Accessor ValidTransportState (Map EndPointId LocalEndPoint)
 localEndPoints = accessor _localEndPoints (\es st -> st { _localEndPoints = es })
 
 nextEndPointId :: Accessor ValidTransportState EndPointId
@@ -2094,7 +2167,7 @@ remoteLastIncoming = accessor _remoteLastIncoming (\lcid st -> st { _remoteLastI
 remoteNextConnOutId :: Accessor ValidRemoteEndPointState LightweightConnectionId
 remoteNextConnOutId = accessor _remoteNextConnOutId (\cix st -> st { _remoteNextConnOutId = cix })
 
-localEndPointAt :: EndPointAddress -> Accessor ValidTransportState (Maybe LocalEndPoint)
+localEndPointAt :: EndPointId -> Accessor ValidTransportState (Maybe LocalEndPoint)
 localEndPointAt addr = localEndPoints >>> DAC.mapMaybe addr
 
 localConnectionTo :: EndPointAddress -> Accessor ValidLocalEndPointState (Maybe RemoteEndPoint)


### PR DESCRIPTION
This makes it feasible to run a transport on a machine that isn't addressable from the network in which its peers live. Endpoints on this transport can connect to the addressable peers, but the peers can only connect to that endpoint if there's already a socket opened. Endpoints on the same unaddressable transport cannot connect to each-other, even though it's technically possible.

Unaddressable endpoints are given (random) UUIDv4 addresses. When an addressable endpoint receives a connection from an unaddressable peer, it generates one to identify that peer *locally* (highly unlikely that any other peer would make sense of that address). This is the address found on the `ConnectionOpened` event.

The connection request protocol (for the socket, not for lightweight connections) is changed: sending a 0-length address (just the length-prefix `0x00000000`) means no address is coming. Anything else will be read and parsed to an `EndPointAddress`. This is backwards compatible assuming empty ByteString is not a valid `EndPointAddress`.