### PR TITLE
Server exception handler is a parameter

### DIFF
--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -507,6 +507,10 @@ data TCPParameters = TCPParameters {
     -- could otherwise deny service to some victim by claiming the victim's
     -- address.
   , tcpCheckPeerHost :: Bool
+    -- | What to do if there's an exception when accepting a new TCP
+    -- connection. Throwing an exception here will cause the server to
+    -- terminate.
+  , tcpServerExceptionHandler :: SomeException -> IO ()
   }
 
 -- | Internal functionality we expose for unit testing
@@ -606,7 +610,7 @@ createTransportExposeInternals bindHost bindPort mkExternal params = do
         )
 
     errorHandler :: TCPTransport -> SomeException -> IO ()
-    errorHandler _ = throwIO
+    errorHandler _ = tcpServerExceptionHandler params
 
     terminationHandler :: TCPTransport -> SomeException -> IO ()
     terminationHandler transport ex = do
@@ -629,6 +633,7 @@ defaultTCPParameters = TCPParameters {
   , tcpMaxAddressLength = maxBound
   , tcpMaxReceiveLength = maxBound
   , tcpCheckPeerHost   = False
+  , tcpServerExceptionHandler = throwIO
   }
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
The server need not crash if `accept` throws an exception.

One example application: if the exception is EMFILE (no more file descriptors available), the server doesn't have to crash, it could just wait before trying to accept again.