### PR TITLE
Add TCP_QUICKACK setting

### DIFF
--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -474,7 +474,7 @@ data TCPParameters = TCPParameters {
     -- Defaults to True.
   , tcpReuseClientAddr :: Bool
     -- | Should we set TCP_NODELAY on connection sockets?
-    -- Defaults to True.
+    -- Defaults to False.
   , tcpNoDelay :: Bool
     -- | Value of TCP_USER_TIMEOUT in milliseconds
   , tcpKeepAlive :: Bool

--- a/src/Network/Transport/TCP/Mock/Socket.hs
+++ b/src/Network/Transport/TCP/Mock/Socket.hs
@@ -40,6 +40,7 @@ import Control.Exception (throwIO)
 import Control.Category ((>>>))
 import Control.Concurrent.MVar
 import Control.Concurrent.Chan
+import Foreign.C.Types (CInt)
 import System.IO.Unsafe (unsafePerformIO)
 import Data.Accessor (Accessor, accessor, (^=), (^.), (^:))
 import qualified Data.Accessor.Container as DAC (mapMaybe)
@@ -94,7 +95,7 @@ type PortNumber  = String
 type HostAddress = String
 
 data SocketType   = Stream
-data SocketOption = ReuseAddr
+data SocketOption = ReuseAddr | CustomSockOpt (CInt, CInt)
 data ShutdownCmd  = ShutdownSend
 
 data Family
@@ -185,6 +186,7 @@ defaultProtocol = error "defaultProtocol not implemented"
 
 setSocketOption :: Socket -> SocketOption -> Int -> IO ()
 setSocketOption _ ReuseAddr 1 = return ()
+setSocketOption _ CustomSockOpt{} _ = return ()
 setSocketOption _ _ _ = error "setSocketOption: unsupported arguments"
 
 accept :: Socket -> IO (Socket, SockAddr)


### PR DESCRIPTION
See the commit messages for details.

I could run the normal tests, but not the mock tests since they don't compile on #master (see haskell-distributed/distributed-process#432).

Related downstream PR: https://github.com/serokell/network-transport-tcp/pull/1