### PR TITLE
Connection timeout only for setup phase

### DIFF
--- a/src/Network/Transport/TCP.hs
+++ b/src/Network/Transport/TCP.hs
@@ -939,6 +939,8 @@ handleConnectionRequest transport socketClosed (sock, sockAddr) = handle handleE
               _ <- recvExact sock handshakeLength
               handleVersioned
     -- The handshake must complete within the optional timeout duration.
+    -- No socket 'recv's are to be run outside the timeout. The continuation
+    -- returned may 'send', but not 'recv'.
     let connTimeout = transportConnectTimeout (transportParams transport)
     outcome <- maybe (fmap Just) System.Timeout.timeout connTimeout handleVersioned
     case outcome of
@@ -996,45 +998,41 @@ handleConnectionRequest transport socketClosed (sock, sockAddr) = handle handleE
                 return ourEndPoint
           TransportClosed ->
             throwIO $ userError "Transport closed"
-        go ourEndPoint theirAddress
+        return (Just (go ourEndPoint theirAddress))
 
       where
 
-      go :: LocalEndPoint -> EndPointAddress -> IO (Maybe (IO ()))
-      go ourEndPoint theirAddress = do
-        -- This runs in a thread that will never be killed
-        mEndPoint <- handle ((>> return Nothing) . handleException) $ do
-          resetIfBroken ourEndPoint theirAddress
-          (theirEndPoint, isNew) <-
-            findRemoteEndPoint ourEndPoint theirAddress RequestedByThem Nothing
+      go :: LocalEndPoint -> EndPointAddress -> IO ()
+      go ourEndPoint theirAddress = handle handleException $ do
+        resetIfBroken ourEndPoint theirAddress
+        (theirEndPoint, isNew) <-
+          findRemoteEndPoint ourEndPoint theirAddress RequestedByThem Nothing
 
-          if not isNew
-            then do
-              void $ tryIO $ sendMany sock
-                [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestCrossed)]
-              probeIfValid theirEndPoint
-              return Nothing
-            else do
-              sendLock <- newMVar ()
-              let vst = ValidRemoteEndPointState
-                          {  remoteSocket        = sock
-                          ,  remoteSocketClosed  = socketClosed
-                          ,  remoteProbing       = Nothing
-                          ,  remoteSendLock      = sendLock
-                          , _remoteOutgoing      = 0
-                          , _remoteIncoming      = Set.empty
-                          , _remoteLastIncoming  = 0
-                          , _remoteNextConnOutId = firstNonReservedLightweightConnectionId
-                          }
-              sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestAccepted)]
-              resolveInit (ourEndPoint, theirEndPoint) (RemoteEndPointValid vst)
-              return (Just theirEndPoint)
-        -- If we left the scope of the exception handler with a return value of
-        -- Nothing then the socket is already closed; otherwise, the socket has
-        -- been recorded as part of the remote endpoint. Either way, we no longer
-        -- have to worry about closing the socket on receiving an asynchronous
-        -- exception from this point forward.
-        return $ fmap (handleIncomingMessages (transportParams transport) . (,) ourEndPoint) mEndPoint
+        if not isNew
+          then do
+            void $ tryIO $ sendMany sock
+              [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestCrossed)]
+            probeIfValid theirEndPoint
+          else do
+            sendLock <- newMVar ()
+            let vst = ValidRemoteEndPointState
+                        {  remoteSocket        = sock
+                        ,  remoteSocketClosed  = socketClosed
+                        ,  remoteProbing       = Nothing
+                        ,  remoteSendLock      = sendLock
+                        , _remoteOutgoing      = 0
+                        , _remoteIncoming      = Set.empty
+                        , _remoteLastIncoming  = 0
+                        , _remoteNextConnOutId = firstNonReservedLightweightConnectionId
+                        }
+            sendMany sock [encodeWord32 (encodeConnectionRequestResponse ConnectionRequestAccepted)]
+            -- resolveInit will update the shared state, and handleIncomingMessages
+            -- will always ultimately clean up after it.
+            -- Closing up the socket is also out of our hands. It will happen
+            -- when handleIncomingMessages finishes.
+            resolveInit (ourEndPoint, theirEndPoint) (RemoteEndPointValid vst)
+              `finally`
+              handleIncomingMessages (transportParams transport) (ourEndPoint, theirEndPoint)
 
       probeIfValid :: RemoteEndPoint -> IO ()
       probeIfValid theirEndPoint = modifyMVar_ (remoteState theirEndPoint) $
@@ -1070,28 +1068,41 @@ handleConnectionRequest transport socketClosed (sock, sockAddr) = handle handleE
 -- Returns only if the remote party closes the socket or if an error occurs.
 -- This runs in a thread that will never be killed.
 handleIncomingMessages :: TCPParameters -> EndPointPair -> IO ()
-handleIncomingMessages params (ourEndPoint, theirEndPoint) = do
-    choice <- withMVar theirState $ \st ->
-      case st of
-        RemoteEndPointInvalid _ ->
-          relyViolation (ourEndPoint, theirEndPoint)
-            "handleIncomingMessages (invalid)"
-        RemoteEndPointInit _ _ _ ->
-          relyViolation (ourEndPoint, theirEndPoint)
-            "handleIncomingMessages (init)"
-        RemoteEndPointValid ep ->
-          return . Right $ remoteSocket ep
-        RemoteEndPointClosing _ ep ->
-          return . Right $ remoteSocket ep
-        RemoteEndPointClosed ->
-          return . Left $ userError "handleIncomingMessages (already closed)"
-        RemoteEndPointFailed _ ->
-          return . Left $ userError "handleIncomingMessages (failed)"
+handleIncomingMessages params (ourEndPoint, theirEndPoint) =
+    bracket acquire release act
 
-    case choice of
-      Left err -> prematureExit err
-      Right sock -> tryIO (go sock) >>= either prematureExit return
   where
+
+    -- Use shared remote endpoint state to get a socket, or an appropriate
+    -- exception in case it's neither valid nor closing.
+    acquire :: IO (Either IOError N.Socket)
+    acquire = withMVar theirState $ \st -> case st of
+      RemoteEndPointInvalid _ ->
+        relyViolation (ourEndPoint, theirEndPoint)
+          "handleIncomingMessages (invalid)"
+      RemoteEndPointInit _ _ _ ->
+        relyViolation (ourEndPoint, theirEndPoint)
+          "handleIncomingMessages (init)"
+      RemoteEndPointValid ep ->
+        return . Right $ remoteSocket ep
+      RemoteEndPointClosing _ ep ->
+        return . Right $ remoteSocket ep
+      RemoteEndPointClosed ->
+        return . Left $ userError "handleIncomingMessages (already closed)"
+      RemoteEndPointFailed _ ->
+        return . Left $ userError "handleIncomingMessages (failed)"
+
+    -- 'Right' is the normal case in which there still is a live socket to
+    -- the remote endpoint, and so 'act' was run and installed its own
+    -- exception handler.
+    release :: Either IOError N.Socket -> IO ()
+    release (Left err) = prematureExit err
+    release (Right _) = return ()
+
+    act :: Either IOError N.Socket -> IO ()
+    act (Left _) = return ()
+    act (Right sock) = go sock `catch` prematureExit
+
     -- Dispatch
     --
     -- If a recv throws an exception this will be caught top-level and


### PR DESCRIPTION
Prior to this patch, the connection timeout was misplaced and
effectively was a connection time limit instead.

```Haskell
{-# LANGUAGE OverloadedStrings #-}

import Network.Transport
import qualified Network.Transport.TCP as TCP
import Control.Concurrent

main = do

  let timeout = 1000000
  let params = TCP.defaultTCPParameters { TCP.transportConnectTimeout = Just timeout }
  Right transport <- TCP.createTransport "127.0.0.1" "7777" ((,) "127.0.0.1") params

  Right server <- newEndPoint transport
  Right client <- newEndPoint transport

  Right conn <- connect client (address server) ReliableOrdered defaultConnectHints

  threadDelay (timeout * 2)

  -- This ought to be 'Right ()' but the timeout has almost certainly killed the socket
  -- by now.
  -- err = TransportError SendFailed "user error (recvExact: Socket closed)"
  Left err <- send conn ["hello world"]

  close conn
  closeEndPoint client
  closeEndPoint server
  closeTransport transport
```