### PR TITLE
Fix possible msg corruption on a busy network

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ next release
 * The server no longer needs crash if accept throws an exception.
 * Check peer-reported host against socket host (#54)
 * Fix possible endless waiting on the 'crossed' MVar (#74)
+* Fix possible msg corruption on a busy network (#85)
 
 2017-08-21 FacundoDominguez <facundo.dominguez@tweag.io> 0.6.0
 

--- a/network-transport-tcp.cabal
+++ b/network-transport-tcp.cabal
@@ -26,6 +26,7 @@ Flag use-mock-network
 
 Library
   Build-Depends:   base >= 4.3 && < 5,
+                   async >= 2.1 && < 2.2,
                    network-transport >= 0.5 && < 0.6,
                    data-accessor >= 0.2 && < 0.3,
                    containers >= 0.4 && < 0.7,


### PR DESCRIPTION
The sendMany routine can send one msg via several c_writev calls
when the OS sending queues are busy. So in between these calls the
sending thread could be interrupted by some outer non-IO exception
(like ProcessLinkException) which caused msg corruption.

Now we call sendMany in a separate thread which is shielded from
outer exceptions.