### PR TITLE
Loosen async dependency.

### DIFF
--- a/network-transport-tcp.cabal
+++ b/network-transport-tcp.cabal
@@ -26,7 +26,7 @@ Flag use-mock-network
 
 Library
   Build-Depends:   base >= 4.3 && < 5,
-                   async >= 2.1 && < 2.2,
+                   async >= 2.2 && < 2.3,
                    network-transport >= 0.5 && < 0.6,
                    data-accessor >= 0.2 && < 0.3,
                    containers >= 0.4 && < 0.7,


### PR DESCRIPTION
We allow latest async package, so n-t-tcp will be buildable under
ghc-8.6.5.