### PR TITLE
Fix deprecated module name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
       addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.5],sources: [hvr-ghc]}}
     - env: CABALVER=2.4 GHCVER=8.8.4
       addons: {apt: {packages: [cabal-install-2.4,ghc-8.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=9.0.1
+      addons: {apt: {packages: [cabal-install-2.4,ghc-9.0.1], sources: [hvr-ghc]}}
 
 cache:
   directories:

--- a/src/Network/Transport/TCP/Internal.hs
+++ b/src/Network/Transport/TCP/Internal.hs
@@ -101,7 +101,7 @@ import qualified Data.ByteString as BS (length, concat, null)
 import Data.ByteString.Lazy.Internal (smallChunkSize)
 import Data.ByteString.Lazy (toStrict)
 import qualified Data.ByteString.Char8 as BSC (unpack, pack)
-import Data.ByteString.Lazy.Builder (word64BE, toLazyByteString)
+import Data.ByteString.Builder (word64BE, toLazyByteString)
 import Data.Monoid ((<>))
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID


### PR DESCRIPTION
This package uses the old name for Data.ByteString.Builder, resulting in build failures for distributed-process on Stackage nightly.